### PR TITLE
Security: fix multiple vulnerabilities identified in audit

### DIFF
--- a/includes/event-reports.php
+++ b/includes/event-reports.php
@@ -127,7 +127,7 @@ function intersoccer_pe_get_camp_report_data($region = '', $week = '', $camp_typ
  */
 function intersoccer_render_event_report_page() {
     try {
-        if (!current_user_can('manage_options') || !current_user_can('coach') || !current_user_can('event_organizer')) {
+        if (!current_user_can('manage_options') && !current_user_can('coach') && !current_user_can('event_organizer')) {
             wp_die(__('You do not have sufficient permissions to access this page.', 'intersoccer-reports-rosters'));
         }
 

--- a/includes/reports-ajax.php
+++ b/includes/reports-ajax.php
@@ -16,12 +16,15 @@ if (!defined('ABSPATH')) {
 function intersoccer_filter_report_callback() {
     check_ajax_referer('intersoccer_reports_filter', 'nonce');
 
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error(['message' => __('You do not have sufficient permissions to access this report.', 'intersoccer-reports-rosters')]);
+        return;
+    }
+
     $start_date = isset($_POST['start_date']) ? sanitize_text_field($_POST['start_date']) : '';
     $end_date = isset($_POST['end_date']) ? sanitize_text_field($_POST['end_date']) : '';
     $year = isset($_POST['year']) ? sanitize_text_field($_POST['year']) : date('Y');
     $region = isset($_POST['region']) ? sanitize_text_field($_POST['region']) : '';
-    
-    error_log("InterSoccer AJAX: Called with start_date=$start_date, end_date=$end_date, year=$year, region=$region");
 
     $visible_columns = isset($_POST['columns']) ? array_map('sanitize_text_field', (array)$_POST['columns']) : [
         'ref', 'booked', 'base_price', 'discount_amount', 'discounts_applied', 'stripe_fee', 'final_price',
@@ -30,16 +33,6 @@ function intersoccer_filter_report_callback() {
 
     // Use the simplified financial reporting function
     $report_data = intersoccer_get_financial_booking_report($start_date, $end_date, $year, $region);
-    
-    error_log("InterSoccer AJAX: report_data returned: " . print_r($report_data, true));
-    error_log("InterSoccer AJAX: report_data type: " . gettype($report_data));
-    if (is_array($report_data)) {
-        error_log("InterSoccer AJAX: report_data has data key: " . (isset($report_data['data']) ? 'yes' : 'no'));
-        error_log("InterSoccer AJAX: report_data has totals key: " . (isset($report_data['totals']) ? 'yes' : 'no'));
-        if (isset($report_data['data'])) {
-            error_log("InterSoccer AJAX: data count: " . count($report_data['data']));
-        }
-    }
 
     ob_start();
     ?>
@@ -131,10 +124,6 @@ function intersoccer_filter_report_callback() {
     
     // Remove totals from table output since they're handled separately
     $table_html = preg_replace('/<div id="intersoccer-report-totals"[^>]*>.*?<\/div>/s', '', $output);
-    
-    error_log("InterSoccer AJAX: About to send JSON response");
-    error_log("InterSoccer AJAX: table_html length: " . strlen($table_html));
-    error_log("InterSoccer AJAX: totals_html length: " . strlen($totals_html));
     
     // Calculate record count
     $record_count = isset($report_data['data']) ? count($report_data['data']) : 0;

--- a/includes/reports.php
+++ b/includes/reports.php
@@ -918,6 +918,11 @@ function intersoccer_office365_build_booking_report_xlsx($report_data, $start_da
 function intersoccer_export_booking_report_callback() {
     check_ajax_referer('intersoccer_reports_filter', 'nonce');
 
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error(['message' => __('You do not have sufficient permissions to export this report.', 'intersoccer-reports-rosters')]);
+        return;
+    }
+
     $start_date = isset($_POST['start_date']) ? sanitize_text_field($_POST['start_date']) : '';
     $end_date = isset($_POST['end_date']) ? sanitize_text_field($_POST['end_date']) : '';
     $year = isset($_POST['year']) ? absint($_POST['year']) : date('Y');

--- a/intersoccer-reports-rosters.php
+++ b/intersoccer-reports-rosters.php
@@ -290,16 +290,16 @@ function intersoccer_render_plugin_overview_page() {
         }
     }
 
-    $current_venue_labels = json_encode(array_column($current_venue_data, 'venue'));
-    $current_venue_values = json_encode(array_column($current_venue_data, 'count'));
-    $region_labels = json_encode(array_column($region_data, 'venue'));
-    $region_values = json_encode(array_column($region_data, 'count'));
-    $age_labels = json_encode(array_column($age_data, 'age_group'));
-    $age_values = json_encode(array_column($age_data, 'count'));
-    $gender_labels = json_encode($ordered_gender_labels);
-    $gender_values = json_encode($ordered_gender_values);
-    $weekly_labels = json_encode(array_column($weekly_trends, 'week_start'));
-    $weekly_values = json_encode(array_column($weekly_trends, 'count'));
+    $current_venue_labels = wp_json_encode(array_column($current_venue_data, 'venue'));
+    $current_venue_values = wp_json_encode(array_column($current_venue_data, 'count'));
+    $region_labels = wp_json_encode(array_column($region_data, 'venue'));
+    $region_values = wp_json_encode(array_column($region_data, 'count'));
+    $age_labels = wp_json_encode(array_column($age_data, 'age_group'));
+    $age_values = wp_json_encode(array_column($age_data, 'count'));
+    $gender_labels = wp_json_encode($ordered_gender_labels);
+    $gender_values = wp_json_encode($ordered_gender_values);
+    $weekly_labels = wp_json_encode(array_column($weekly_trends, 'week_start'));
+    $weekly_values = wp_json_encode(array_column($weekly_trends, 'count'));
 
     ?>
     <div class="wrap">


### PR DESCRIPTION
- Missing authorization: add current_user_can('manage_options') check to
  intersoccer_filter_report_callback() and intersoccer_export_booking_report_callback();
  previously any logged-in user could read/export financial booking reports.

- Stored XSS: replace json_encode() with wp_json_encode() for all chart data
  injected into inline <script> blocks in intersoccer_render_plugin_overview_page();
  wp_json_encode() escapes </script> sequences that plain json_encode() leaves raw.

- SQL injection via column name: add an allowlist of permitted column identifiers
  in RosterRepository::getByDateRange(); previously caller-supplied array keys were
  interpolated directly into the SQL string without validation.

- Mass-assignment via missing allowlist: replace the denylist approach in
  intersoccer_ajax_update_roster_entry() with an explicit allowlist of editable
  fields; previously any column not in a small denylist could be overwritten.
  Also removed error detail leakage from the 'Update failed' response.

- Logic error: fix || vs && in intersoccer_render_event_report_page() capability
  check; the old condition required a user to hold all three roles simultaneously,
  making the page unreachable; it now correctly allows access to anyone holding
  manage_options OR coach OR event_organizer.

- Debug logging: remove unconditional error_log() calls that dumped the full
  $_POST payload (including any sensitive values) and raw report data to the
  server log in production (intersoccer_process_existing_orders_ajax() and
  intersoccer_filter_report_callback()).

- Unsanitized nonce input: sanitize + unslash nonce POST fields with
  sanitize_text_field(wp_unslash(...)) before passing to wp_verify_nonce()
  in the legacy intersoccer_process_existing_orders_ajax() handler.

https://claude.ai/code/session_01EZyzKDDRzfPLev6hu5JzXy