### PR TITLE
Unify roster admin listing and harden listing aggregates.

### DIFF
--- a/classes/Admin/asset-manager.php
+++ b/classes/Admin/asset-manager.php
@@ -73,9 +73,11 @@ class AssetManager {
         // Roster listing pages (tabs + close/reopen actions)
         $roster_pages = [
             'intersoccer-reports-rosters_page_intersoccer-all-rosters',
+            'intersoccer-reports-rosters_page_intersoccer-rosters',
             'intersoccer-reports-rosters_page_intersoccer-camps',
             'intersoccer-reports-rosters_page_intersoccer-courses',
             'intersoccer-reports-rosters_page_intersoccer-girls-only',
+            'intersoccer-reports-rosters_page_intersoccer-tournaments',
             'intersoccer-reports-rosters_page_intersoccer-other-events',
             'intersoccer-reports-rosters_page_intersoccer-birthdays',
         ];
@@ -138,7 +140,13 @@ class AssetManager {
             $screen_id === 'intersoccer-reports-rosters_page_intersoccer-roster-sync-queue'
             || $screen_id === 'reports-and-rosters_page_intersoccer-roster-sync-queue'
             || $hook === 'intersoccer-reports-rosters_page_intersoccer-roster-sync-queue'
-            || $hook === 'reports-and-rosters_page_intersoccer-roster-sync-queue';
+            || $hook === 'reports-and-rosters_page_intersoccer-roster-sync-queue'
+            || (
+                ($screen_id === 'intersoccer-reports-rosters_page_intersoccer-advanced'
+                    || $hook === 'intersoccer-reports-rosters_page_intersoccer-advanced')
+                && isset($_GET['tab'])
+                && sanitize_key(wp_unslash((string) $_GET['tab'])) === 'roster-sync'
+            );
 
         if ($is_advanced_screen || $is_roster_sync_screen) {
             $advanced_js_path = dirname(__DIR__, 2) . '/js/advanced-ajax.js';

--- a/classes/Admin/menu-manager.php
+++ b/classes/Admin/menu-manager.php
@@ -78,6 +78,7 @@ class MenuManager {
         // Plugin invokes register_menus() directly (not init()); must register export here
         // so admin_init/load-* fire before admin-header HTML contaminates the .xlsx.
         add_action('admin_init', [$this, 'maybe_export_player_camp_status'], 1);
+        add_action('admin_init', [$this, 'maybe_redirect_legacy_admin_pages'], 1);
 
         add_menu_page(
             __('InterSoccer Reports and Rosters', 'intersoccer-reports-rosters'),
@@ -157,39 +158,18 @@ class MenuManager {
 
         add_submenu_page(
             'intersoccer-reports-rosters',
-            __('Camps', 'intersoccer-reports-rosters'),
-            __('Camps', 'intersoccer-reports-rosters'),
+            __('Rosters', 'intersoccer-reports-rosters'),
+            __('Rosters', 'intersoccer-reports-rosters'),
             'read',
-            'intersoccer-camps',
-            [$this, 'render_camps']
+            'intersoccer-rosters',
+            [$this, 'render_rosters']
         );
 
-        add_submenu_page(
-            'intersoccer-reports-rosters',
-            __('Courses', 'intersoccer-reports-rosters'),
-            __('Courses', 'intersoccer-reports-rosters'),
-            'read',
-            'intersoccer-courses',
-            [$this, 'render_courses']
-        );
-
-        add_submenu_page(
-            'intersoccer-reports-rosters',
-            __('Girls Only', 'intersoccer-reports-rosters'),
-            __('Girls Only', 'intersoccer-reports-rosters'),
-            'read',
-            'intersoccer-girls-only',
-            [$this, 'render_girls_only']
-        );
-
-        add_submenu_page(
-            'intersoccer-reports-rosters',
-            __('Tournaments', 'intersoccer-reports-rosters'),
-            __('Tournaments', 'intersoccer-reports-rosters'),
-            'read',
-            'intersoccer-tournaments',
-            [$this, 'render_tournaments']
-        );
+        // Hidden legacy list pages → unified Rosters with activity_type.
+        add_submenu_page(null, '', '', 'read', 'intersoccer-camps', [$this, 'render_legacy_camps_redirect']);
+        add_submenu_page(null, '', '', 'read', 'intersoccer-courses', [$this, 'render_legacy_courses_redirect']);
+        add_submenu_page(null, '', '', 'read', 'intersoccer-girls-only', [$this, 'render_legacy_girls_only_redirect']);
+        add_submenu_page(null, '', '', 'read', 'intersoccer-tournaments', [$this, 'render_legacy_tournaments_redirect']);
 
         add_submenu_page(
             'intersoccer-reports-rosters',
@@ -227,13 +207,14 @@ class MenuManager {
             [$this, 'render_advanced']
         );
 
+        // Hidden: Roster Sync Queue lives under Settings → Roster Sync Queue tab.
         add_submenu_page(
-            'intersoccer-reports-rosters',
-            __('Roster Sync Queue', 'intersoccer-reports-rosters'),
-            __('Roster Sync Queue', 'intersoccer-reports-rosters'),
+            null,
+            '',
+            '',
             'manage_options',
             'intersoccer-roster-sync-queue',
-            [$this, 'render_roster_sync_queue']
+            [$this, 'render_roster_sync_queue_redirect']
         );
 
         // Hidden detail/edit pages
@@ -254,6 +235,35 @@ class MenuManager {
             'intersoccer-roster-edit',
             [$this, 'render_roster_edit']
         );
+    }
+
+
+    /**
+     * Redirect legacy list / sync-queue bookmarks before headers are sent.
+     */
+    public function maybe_redirect_legacy_admin_pages(): void {
+        if (!is_admin()) {
+            return;
+        }
+
+        $page = isset($_GET['page']) ? sanitize_key(wp_unslash((string) $_GET['page'])) : '';
+        if ($page === '') {
+            return;
+        }
+
+        $this->require_include('rosters.php');
+
+        if ($page === 'intersoccer-roster-sync-queue') {
+            if (!headers_sent()) {
+                wp_safe_redirect(admin_url('admin.php?page=intersoccer-advanced&tab=roster-sync'));
+                exit;
+            }
+            return;
+        }
+
+        if (function_exists('intersoccer_rosters_maybe_redirect_legacy_list_page')) {
+            intersoccer_rosters_maybe_redirect_legacy_list_page($page);
+        }
     }
 
     private function require_include(string $relative_file): void {
@@ -335,40 +345,42 @@ class MenuManager {
         wp_die(__('All rosters page is not available.', 'intersoccer-reports-rosters'));
     }
 
-    public function render_camps(): void {
+    public function render_rosters(): void {
         $this->require_include('rosters.php');
-        if (function_exists('intersoccer_render_camps_page')) {
-            intersoccer_render_camps_page();
+        if (function_exists('intersoccer_render_rosters_page')) {
+            intersoccer_render_rosters_page();
             return;
         }
-        wp_die(__('Camps page is not available.', 'intersoccer-reports-rosters'));
+        wp_die(__('Rosters page is not available.', 'intersoccer-reports-rosters'));
     }
 
-    public function render_courses(): void {
-        $this->require_include('rosters.php');
-        if (function_exists('intersoccer_render_courses_page')) {
-            intersoccer_render_courses_page();
-            return;
-        }
-        wp_die(__('Courses page is not available.', 'intersoccer-reports-rosters'));
+    public function render_legacy_camps_redirect(): void {
+        $this->redirect_legacy_list_page('camps');
     }
 
-    public function render_girls_only(): void {
-        $this->require_include('rosters.php');
-        if (function_exists('intersoccer_render_girls_only_page')) {
-            intersoccer_render_girls_only_page();
-            return;
-        }
-        wp_die(__('Girls Only page is not available.', 'intersoccer-reports-rosters'));
+    public function render_legacy_courses_redirect(): void {
+        $this->redirect_legacy_list_page('courses');
     }
 
-    public function render_tournaments(): void {
+    public function render_legacy_girls_only_redirect(): void {
+        $this->redirect_legacy_list_page('girls_only');
+    }
+
+    public function render_legacy_tournaments_redirect(): void {
+        $this->redirect_legacy_list_page('tournaments');
+    }
+
+    /**
+     * @param string $activity_type camps|courses|girls_only|tournaments
+     */
+    private function redirect_legacy_list_page(string $activity_type): void {
         $this->require_include('rosters.php');
-        if (function_exists('intersoccer_render_tournaments_page')) {
-            intersoccer_render_tournaments_page();
-            return;
+        if (function_exists('intersoccer_rosters_unified_url')) {
+            wp_safe_redirect(intersoccer_rosters_unified_url($activity_type, $_GET));
+            exit;
         }
-        wp_die(__('Tournaments page is not available.', 'intersoccer-reports-rosters'));
+        wp_safe_redirect(admin_url('admin.php?page=intersoccer-rosters&activity_type=' . rawurlencode($activity_type)));
+        exit;
     }
 
     public function render_other_events(): void {
@@ -402,13 +414,9 @@ class MenuManager {
         wp_die(__('Advanced page is not available.', 'intersoccer-reports-rosters'));
     }
 
-    public function render_roster_sync_queue(): void {
-        $this->require_include('advanced.php');
-        if (function_exists('intersoccer_render_roster_sync_queue_admin_page')) {
-            intersoccer_render_roster_sync_queue_admin_page();
-            return;
-        }
-        wp_die(__('Roster Sync Queue page is not available.', 'intersoccer-reports-rosters'));
+    public function render_roster_sync_queue_redirect(): void {
+        wp_safe_redirect(admin_url('admin.php?page=intersoccer-advanced&tab=roster-sync'));
+        exit;
     }
 
     public function render_signature_drift(): void {
@@ -438,4 +446,3 @@ class MenuManager {
         wp_die(__('Roster edit page is not available.', 'intersoccer-reports-rosters'));
     }
 }
-

--- a/classes/Core/Plugin.php
+++ b/classes/Core/Plugin.php
@@ -335,7 +335,7 @@ final class Plugin {
             return;
         }
         // Load rosters.php early (before admin_head) when on a roster page so card CSS is registered
-        $roster_pages = ['intersoccer-camps', 'intersoccer-courses', 'intersoccer-girls-only', 'intersoccer-tournaments', 'intersoccer-other-events', 'intersoccer-all-rosters', 'intersoccer-birthdays'];
+        $roster_pages = ['intersoccer-rosters', 'intersoccer-camps', 'intersoccer-courses', 'intersoccer-girls-only', 'intersoccer-tournaments', 'intersoccer-other-events', 'intersoccer-all-rosters', 'intersoccer-birthdays'];
         $page = isset($_GET['page']) ? sanitize_text_field(wp_unslash($_GET['page'])) : '';
         if (in_array($page, $roster_pages, true)) {
             $includes_to_load = [$this->plugin_path . 'includes/rosters.php'];

--- a/classes/Core/database.php
+++ b/classes/Core/database.php
@@ -725,6 +725,144 @@ class Database {
             return false;
         }
     }
+
+    /**
+     * Allowed WooCommerce order statuses for admin roster listings.
+     *
+     * @return string[]
+     */
+    public function get_listing_allowed_order_statuses() {
+        return ['wc-completed', 'wc-processing', 'wc-pending', 'wc-on-hold'];
+    }
+
+    /**
+     * Fetch roster listing aggregates (one row per event_signature) with order-status JOIN.
+     *
+     * Avoids SELECT * of player payloads and per-row get_post_status() lookups.
+     *
+     * @param array $filters Column filters (activity_type, venue, camp_terms, …). Values may be scalars or arrays.
+     * @param array $options Optional: skip_cache (unused here), order_statuses override.
+     * @return array<int,array<string,mixed>>|false Aggregate rows or false on failure.
+     */
+    public function get_roster_listing_aggregates(array $filters = [], array $options = []) {
+        try {
+            $table_name = $this->wpdb->prefix . 'intersoccer_rosters';
+            $posts_table = $this->wpdb->posts;
+
+            $allowed_fields = [
+                'activity_type',
+                'is_placeholder',
+                'event_completed',
+                'girls_only',
+                'venue',
+                'camp_terms',
+                'course_day',
+                'age_group',
+                'city',
+                'times',
+                'product_id',
+                'variation_id',
+            ];
+
+            $where_conditions = ['r.order_id > 0'];
+            $where_values = [];
+
+            foreach ($filters as $field => $value) {
+                if (!in_array($field, $allowed_fields, true)) {
+                    continue;
+                }
+                $column = 'r.' . $field;
+                if (is_array($value)) {
+                    if ($value === []) {
+                        continue;
+                    }
+                    $placeholders = implode(',', array_fill(0, count($value), '%s'));
+                    $where_conditions[] = "{$column} IN ({$placeholders})";
+                    $where_values = array_merge($where_values, array_values($value));
+                } elseif ($value === null) {
+                    $where_conditions[] = "{$column} IS NULL";
+                } else {
+                    $where_conditions[] = "{$column} = %s";
+                    $where_values[] = $value;
+                }
+            }
+
+            $statuses = !empty($options['order_statuses']) && is_array($options['order_statuses'])
+                ? array_values($options['order_statuses'])
+                : $this->get_listing_allowed_order_statuses();
+            $status_placeholders = implode(',', array_fill(0, count($statuses), '%s'));
+            $where_conditions[] = "p.post_status IN ({$status_placeholders})";
+            $where_values = array_merge($where_values, $statuses);
+
+            $group_key_expr = "CASE
+                WHEN r.event_signature IS NOT NULL AND r.event_signature != '' THEN r.event_signature
+                ELSE CONCAT(
+                    'fb|',
+                    IFNULL(r.product_id, 0), '|',
+                    IFNULL(r.venue, ''), '|',
+                    IFNULL(r.camp_terms, ''), '|',
+                    IFNULL(r.course_day, ''), '|',
+                    IFNULL(r.start_date, ''), '|',
+                    IFNULL(r.age_group, '')
+                )
+            END";
+
+            // Allow large GROUP_CONCAT for order_item_ids / variation_ids on busy events.
+            $this->wpdb->query('SET SESSION group_concat_max_len = 1000000');
+
+            $sql = "
+                SELECT
+                    {$group_key_expr} AS group_key,
+                    MAX(r.event_signature) AS event_signature,
+                    COUNT(DISTINCT r.order_item_id) AS player_count,
+                    MAX(r.product_id) AS product_id,
+                    MAX(r.product_name) AS product_name,
+                    MAX(r.variation_id) AS variation_id,
+                    MAX(r.venue) AS venue,
+                    MAX(r.city) AS city,
+                    MAX(r.age_group) AS age_group,
+                    MAX(r.camp_terms) AS camp_terms,
+                    MAX(r.course_day) AS course_day,
+                    MAX(r.times) AS times,
+                    MAX(r.season) AS season,
+                    MAX(r.activity_type) AS activity_type,
+                    MAX(r.start_date) AS start_date,
+                    MAX(r.end_date) AS end_date,
+                    MAX(r.event_completed) AS event_completed,
+                    MAX(r.girls_only) AS girls_only,
+                    GROUP_CONCAT(DISTINCT NULLIF(r.order_item_id, 0) ORDER BY r.order_item_id SEPARATOR ',') AS order_item_ids_csv,
+                    GROUP_CONCAT(DISTINCT NULLIF(r.variation_id, 0) ORDER BY r.variation_id SEPARATOR ',') AS variation_ids_csv,
+                    GROUP_CONCAT(DISTINCT NULLIF(r.event_signature, '') ORDER BY r.event_signature SEPARATOR ',') AS event_signatures_csv
+                FROM {$table_name} r
+                INNER JOIN {$posts_table} p ON p.ID = r.order_id
+                WHERE " . implode(' AND ', $where_conditions) . "
+                GROUP BY {$group_key_expr}
+            ";
+
+            $prepared = $this->wpdb->prepare($sql, $where_values);
+            if ($prepared === false || $prepared === null) {
+                throw new DatabaseException('Failed to prepare listing aggregates query: ' . $this->wpdb->last_error);
+            }
+
+            $results = $this->wpdb->get_results($prepared, ARRAY_A);
+            if ($results === null) {
+                throw new DatabaseException('Listing aggregates query failed: ' . $this->wpdb->last_error);
+            }
+
+            $this->logger->debug('Retrieved roster listing aggregates', [
+                'count' => count($results),
+                'filters' => $filters,
+            ]);
+
+            return $results;
+        } catch (\Exception $e) {
+            $this->logger->error('Failed to get roster listing aggregates', [
+                'error' => $e->getMessage(),
+                'filters' => $filters,
+            ]);
+            return false;
+        }
+    }
     
     /**
      * Get roster entries count with filters

--- a/classes/data/repositories/roster-repository.php
+++ b/classes/data/repositories/roster-repository.php
@@ -405,6 +405,49 @@ class RosterRepository implements RepositoryInterface {
             return new RostersCollection();
         }
     }
+
+    /**
+     * Listing aggregates for admin roster cards (status JOIN + GROUP BY event_signature).
+     *
+     * @param array $criteria Column filters
+     * @param array $options  Query options (skip_cache, order_statuses)
+     * @return array<int,array<string,mixed>>
+     */
+    public function getListingAggregates(array $criteria, array $options = []) {
+        try {
+            $skip_cache = !empty($options['skip_cache']);
+            $cache_key = 'roster_listing_agg_v1_' . md5(serialize([
+                'criteria' => $criteria,
+                'statuses' => $options['order_statuses'] ?? null,
+            ]));
+
+            if (!$skip_cache) {
+                $cached = $this->cache->get($cache_key);
+                if (is_array($cached)) {
+                    $this->logger->debug('Retrieved roster listing aggregates from cache');
+                    return $cached;
+                }
+            }
+
+            $rows = $this->database->get_roster_listing_aggregates($criteria, $options);
+            if ($rows === false) {
+                return [];
+            }
+
+            if (!$skip_cache) {
+                // Short-lived: listing cards refresh often after sync (5 minutes).
+                $this->cache->set($cache_key, $rows, 'default', 300);
+            }
+
+            return $rows;
+        } catch (\Exception $e) {
+            $this->logger->error('Failed to get listing aggregates', [
+                'criteria' => $criteria,
+                'error' => $e->getMessage(),
+            ]);
+            return [];
+        }
+    }
     
     /**
      * Count roster entries matching criteria

--- a/classes/services/roster-listing-service.php
+++ b/classes/services/roster-listing-service.php
@@ -74,13 +74,13 @@ class RosterListingService {
         }
         // If status is 'all', don't filter by event_completed
 
-        if (!empty($context['accessible_venues'])) {
-            $criteria['venue'] = $context['accessible_venues'];
-        }
+        $criteria = $this->applyListingFacetCriteria($criteria, $filters, $context, ['venue', 'camp_terms', 'age_group', 'city']);
 
         $start_time = microtime(true);
-        $collection = $this->repository->where($criteria);
-        $rosters = $this->filterListingRows($this->prepareRosterArray($collection), 'camp');
+        $aggregates = $this->repository->getListingAggregates($criteria, [
+            'order_statuses' => $this->allowed_statuses,
+        ]);
+        $rosters = $this->filterListingRows($this->mapListingAggregatesToRows($aggregates), 'camp');
         $query_time = microtime(true) - $start_time;
 
         $girls_only_mode = $this->normaliseGirlsOnlyMode($filters['girls_only_mode'] ?? '');
@@ -149,6 +149,108 @@ class RosterListingService {
                 'cities' => [],
             ],
         ];
+    }
+
+    /**
+     * Push UI facet filters into SQL criteria (season stays PHP-side).
+     *
+     * @param string[] $facet_keys
+     */
+    private function applyListingFacetCriteria(array $criteria, array $filters, array $context, array $facet_keys): array {
+        $selected_venue = isset($filters['venue']) ? (string) $filters['venue'] : '';
+        $coach_venues = !empty($context['accessible_venues']) ? array_values((array) $context['accessible_venues']) : [];
+
+        if ($selected_venue !== '') {
+            if ($coach_venues !== [] && !in_array($selected_venue, $coach_venues, true)) {
+                $criteria['venue'] = ['__no_match__'];
+            } else {
+                $criteria['venue'] = $selected_venue;
+            }
+        } elseif ($coach_venues !== []) {
+            $criteria['venue'] = $coach_venues;
+        }
+
+        foreach ($facet_keys as $key) {
+            if ($key === 'venue') {
+                continue;
+            }
+            if (!empty($filters[$key])) {
+                $criteria[$key] = $filters[$key];
+            }
+        }
+
+        return $criteria;
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $aggregates
+     * @return array<int,array<string,mixed>>
+     */
+    private function mapListingAggregatesToRows(array $aggregates): array {
+        $rows = [];
+        foreach ($aggregates as $agg) {
+            if (!is_array($agg)) {
+                continue;
+            }
+            $order_item_ids = $this->parseCsvIntList($agg['order_item_ids_csv'] ?? '');
+            $variation_ids = $this->parseCsvIntList($agg['variation_ids_csv'] ?? '');
+            $sigs = [];
+            foreach (explode(',', (string) ($agg['event_signatures_csv'] ?? '')) as $sig) {
+                $sig = trim($sig);
+                if ($sig !== '') {
+                    $sigs[] = $sig;
+                }
+            }
+
+            $row = [
+                'event_signature' => (string) ($agg['event_signature'] ?? $agg['group_key'] ?? ''),
+                'product_id' => (int) ($agg['product_id'] ?? 0),
+                'product_name' => (string) ($agg['product_name'] ?? 'N/A'),
+                'variation_id' => (int) ($agg['variation_id'] ?? 0),
+                'venue' => (string) ($agg['venue'] ?? 'N/A'),
+                'city' => (string) ($agg['city'] ?? 'N/A'),
+                'age_group' => (string) ($agg['age_group'] ?? 'N/A'),
+                'camp_terms' => (string) ($agg['camp_terms'] ?? 'N/A'),
+                'course_day' => (string) ($agg['course_day'] ?? ''),
+                'times' => (string) ($agg['times'] ?? 'N/A'),
+                'season' => (string) ($agg['season'] ?? 'N/A'),
+                'activity_type' => (string) ($agg['activity_type'] ?? ''),
+                'start_date' => (string) ($agg['start_date'] ?? ''),
+                'end_date' => (string) ($agg['end_date'] ?? ''),
+                'event_completed' => (int) ($agg['event_completed'] ?? 0),
+                'girls_only' => (int) ($agg['girls_only'] ?? 0),
+                'order_item_id' => $order_item_ids[0] ?? 0,
+                'order_item_ids' => $order_item_ids,
+                'variation_ids' => $variation_ids,
+                'merged_event_signatures' => $sigs,
+                'player_count' => (int) ($agg['player_count'] ?? count($order_item_ids)),
+                '_listing_aggregate' => true,
+            ];
+
+            if (function_exists('intersoccer_roster_normalize_row_facets_for_display')) {
+                $row = intersoccer_roster_normalize_row_facets_for_display($row);
+            }
+
+            $rows[] = $row;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return int[]
+     */
+    private function parseCsvIntList($csv): array {
+        $out = [];
+        foreach (explode(',', (string) $csv) as $part) {
+            $part = trim($part);
+            if ($part === '' || !ctype_digit($part)) {
+                continue;
+            }
+            $out[] = (int) $part;
+        }
+
+        return array_values(array_unique($out));
     }
 
     private function prepareRosterArray($collection): array {
@@ -280,13 +382,13 @@ class RosterListingService {
         }
         // If status is 'all', don't filter by event_completed
 
-        if (!empty($context['accessible_venues'])) {
-            $criteria['venue'] = $context['accessible_venues'];
-        }
+        $criteria = $this->applyListingFacetCriteria($criteria, $filters, $context, ['venue', 'course_day', 'age_group', 'city']);
 
         $start_time = microtime(true);
-        $collection = $this->repository->where($criteria);
-        $rosters = $this->filterListingRows($this->prepareRosterArray($collection), 'course');
+        $aggregates = $this->repository->getListingAggregates($criteria, [
+            'order_statuses' => $this->allowed_statuses,
+        ]);
+        $rosters = $this->filterListingRows($this->mapListingAggregatesToRows($aggregates), 'course');
 
         // Recover course products stored under camp-shaped activity_type (mis-labeled only; camp facets excluded in filter).
         if (!$girls_only) {
@@ -294,8 +396,10 @@ class RosterListingService {
             $mislabel_criteria['activity_type'] = function_exists('intersoccer_roster_listing_activity_types')
                 ? intersoccer_roster_listing_activity_types('camp')
                 : [Roster::ACTIVITY_CAMP, 'Camp, Girls Only', "Camp, Girls' only"];
-            $mislabel_collection = $this->repository->where($mislabel_criteria);
-            $recovered = $this->filterListingRows($this->prepareRosterArray($mislabel_collection), 'course');
+            $mislabel_aggregates = $this->repository->getListingAggregates($mislabel_criteria, [
+                'order_statuses' => $this->allowed_statuses,
+            ]);
+            $recovered = $this->filterListingRows($this->mapListingAggregatesToRows($mislabel_aggregates), 'course');
             $rosters = $this->mergeListingRowsByOrderItemId($rosters, $recovered);
         }
 
@@ -436,17 +540,7 @@ class RosterListingService {
             $group =& $groups[$signature];
             $group['girls_only'] = max((int) ($group['girls_only'] ?? 0), (int) ($row['girls_only'] ?? 0));
 
-            if (!empty($row['event_signature'])) {
-                $group['merged_event_signatures'][$row['event_signature']] = true;
-            }
-
-            if (!empty($row['variation_id'])) {
-                $group['variation_ids'][$row['variation_id']] = $row['variation_id'];
-            }
-
-            if (!empty($row['order_item_id'])) {
-                $group['order_item_ids'][$row['order_item_id']] = true;
-            }
+            $this->mergeListingRowIdsIntoGroup($group, $row);
 
             if (!empty($row['start_date'])) {
                 $group['start_dates'][] = $row['start_date'];
@@ -636,6 +730,7 @@ class RosterListingService {
 
         $criteria = [
             'is_placeholder' => 0,
+            'girls_only' => 1,
         ];
 
         if (isset($filters['status']) && $filters['status'] === 'closed') {
@@ -644,13 +739,13 @@ class RosterListingService {
             $criteria['event_completed'] = 0;
         }
 
-        if (!empty($context['accessible_venues'])) {
-            $criteria['venue'] = $context['accessible_venues'];
-        }
+        $criteria = $this->applyListingFacetCriteria($criteria, $filters, $context, ['venue', 'camp_terms', 'course_day', 'age_group', 'city']);
 
         $start_time = microtime(true);
-        $collection = $this->repository->where($criteria, ['skip_cache' => true]);
-        $prepared = $this->prepareRosterArray($collection);
+        $aggregates = $this->repository->getListingAggregates($criteria, [
+            'order_statuses' => $this->allowed_statuses,
+        ]);
+        $prepared = $this->mapListingAggregatesToRows($aggregates);
         $rosters = $this->filterGirlsOnlyListingRows($prepared);
         $query_time = microtime(true) - $start_time;
 
@@ -699,13 +794,13 @@ class RosterListingService {
             'is_placeholder' => 0,
         ];
 
-        if (!empty($context['accessible_venues'])) {
-            $criteria['venue'] = $context['accessible_venues'];
-        }
+        $criteria = $this->applyListingFacetCriteria($criteria, $filters, $context, ['venue', 'age_group', 'city', 'times']);
 
         $start_time = microtime(true);
-        $collection = $this->repository->where($criteria);
-        $rosters = $this->prepareRosterArray($collection);
+        $aggregates = $this->repository->getListingAggregates($criteria, [
+            'order_statuses' => $this->allowed_statuses,
+        ]);
+        $rosters = $this->mapListingAggregatesToRows($aggregates);
         $query_time = microtime(true) - $start_time;
 
         if (empty($rosters)) {
@@ -812,11 +907,8 @@ class RosterListingService {
                 $group =& $camps[$signature];
             }
 
-            if (!empty($row['variation_id'])) {
-                $group['variation_ids'][$row['variation_id']] = $row['variation_id'];
-            }
-            if (!empty($row['order_item_id'])) {
-                $group['order_item_ids'][$row['order_item_id']] = true;
+            if (!empty($row['variation_id']) || !empty($row['_listing_aggregate']) || !empty($row['order_item_id'])) {
+                $this->mergeListingRowIdsIntoGroup($group, $row);
             }
             if (!empty($row['start_date'])) {
                 $group['start_dates'][] = $row['start_date'];
@@ -904,44 +996,53 @@ class RosterListingService {
 
     private function applyGirlsFilters(array $groups, array $filters): array {
         return array_values(array_filter($groups, function ($group) use ($filters) {
-            if ($filters['season']) {
+            $season = (string) ($filters['season'] ?? '');
+            $type = (string) ($filters['type'] ?? '');
+            $venue = (string) ($filters['venue'] ?? '');
+            $camp_terms = (string) ($filters['camp_terms'] ?? '');
+            $course_day = (string) ($filters['course_day'] ?? '');
+            $age_group = (string) ($filters['age_group'] ?? '');
+            $city = (string) ($filters['city'] ?? '');
+
+            if ($season !== '') {
                 if (function_exists('intersoccer_roster_listing_season_filter_matches')) {
                     $row = [
                         'season' => (string) ($group['season_raw'] ?? $group['season'] ?? ''),
                         'start_date' => (string) ($group['corrected_start_date'] ?? $group['start_date'] ?? ''),
                         'product_name' => (string) ($group['product_name'] ?? ''),
                     ];
-                    if (!intersoccer_roster_listing_season_filter_matches($row, $filters['season'], 'camp')) {
+                    $season_kind = $type === 'courses' ? 'course' : 'camp';
+                    if (!intersoccer_roster_listing_season_filter_matches($row, $season, $season_kind)) {
                         return false;
                     }
-                } elseif ($group['season'] !== $filters['season'] && $group['season_raw'] !== $filters['season']) {
+                } elseif (($group['season'] ?? '') !== $season && ($group['season_raw'] ?? '') !== $season) {
                     return false;
                 }
             }
-            if ($filters['venue'] && $group['venue'] !== $filters['venue']) {
+            if ($venue !== '' && ($group['venue'] ?? '') !== $venue) {
                 return false;
             }
-            if ($filters['type'] === 'camps') {
+            if ($type === 'camps') {
                 $is_camp = !empty($group['camp_terms']) && $group['camp_terms'] !== 'N/A';
                 if (!$is_camp) {
                     return false;
                 }
-            } elseif ($filters['type'] === 'courses') {
+            } elseif ($type === 'courses') {
                 $is_camp = !empty($group['camp_terms']) && $group['camp_terms'] !== 'N/A';
                 if ($is_camp) {
                     return false;
                 }
             }
-            if ($filters['camp_terms'] && (!isset($group['camp_terms']) || $group['camp_terms'] !== $filters['camp_terms'])) {
+            if ($camp_terms !== '' && (!isset($group['camp_terms']) || $group['camp_terms'] !== $camp_terms)) {
                 return false;
             }
-            if ($filters['course_day'] && (!isset($group['course_day']) || $group['course_day'] !== $filters['course_day'])) {
+            if ($course_day !== '' && (!isset($group['course_day']) || $group['course_day'] !== $course_day)) {
                 return false;
             }
-            if ($filters['age_group'] && $group['age_group'] !== $filters['age_group']) {
+            if ($age_group !== '' && ($group['age_group'] ?? '') !== $age_group) {
                 return false;
             }
-            if ($filters['city'] && $group['city'] !== $filters['city']) {
+            if ($city !== '' && ($group['city'] ?? '') !== $city) {
                 return false;
             }
             return true;
@@ -1083,12 +1184,7 @@ class RosterListingService {
             }
 
             $group =& $groups[$signature];
-            if (!empty($row['variation_id'])) {
-                $group['variation_ids'][$row['variation_id']] = $row['variation_id'];
-            }
-            if (!empty($row['order_item_id'])) {
-                $group['order_item_ids'][$row['order_item_id']] = true;
-            }
+            $this->mergeListingRowIdsIntoGroup($group, $row);
             if (!empty($row['start_date']) && $row['start_date'] !== '1970-01-01') {
                 $group['start_dates'][] = $row['start_date'];
             }
@@ -1227,17 +1323,7 @@ class RosterListingService {
             $group['event_completed'] = max((int) ($group['event_completed'] ?? 0), !empty($row['event_completed']) ? 1 : 0);
             $group['girls_only'] = max((int) ($group['girls_only'] ?? 0), (int) ($row['girls_only'] ?? 0));
 
-            if (!empty($row['event_signature'])) {
-                $group['merged_event_signatures'][$row['event_signature']] = true;
-            }
-
-            if (!empty($row['variation_id'])) {
-                $group['variation_ids'][$row['variation_id']] = $row['variation_id'];
-            }
-
-            if (!empty($row['order_item_id'])) {
-                $group['order_item_ids'][$row['order_item_id']] = true;
-            }
+            $this->mergeListingRowIdsIntoGroup($group, $row);
 
             if (!empty($row['start_date'])) {
                 $group['start_dates'][] = $row['start_date'];
@@ -1286,6 +1372,59 @@ class RosterListingService {
             'groups' => $groups,
             'filters' => $filters,
         ];
+    }
+
+    /**
+     * Merge order_item / variation / signature ids from a listing row into a group bucket.
+     *
+     * @param array<string,mixed> $group
+     * @param array<string,mixed> $row
+     */
+    private function mergeListingRowIdsIntoGroup(array &$group, array $row): void {
+        if (!isset($group['merged_event_signatures']) || !is_array($group['merged_event_signatures'])) {
+            $group['merged_event_signatures'] = [];
+        }
+        if (!isset($group['variation_ids']) || !is_array($group['variation_ids'])) {
+            $group['variation_ids'] = [];
+        }
+        if (!isset($group['order_item_ids']) || !is_array($group['order_item_ids'])) {
+            $group['order_item_ids'] = [];
+        }
+
+        if (!empty($row['_listing_aggregate'])) {
+            foreach ((array) ($row['merged_event_signatures'] ?? []) as $sig) {
+                $sig = trim((string) $sig);
+                if ($sig !== '') {
+                    $group['merged_event_signatures'][$sig] = true;
+                }
+            }
+            if (!empty($row['event_signature'])) {
+                $group['merged_event_signatures'][$row['event_signature']] = true;
+            }
+            foreach ((array) ($row['variation_ids'] ?? []) as $vid) {
+                $vid = (int) $vid;
+                if ($vid > 0) {
+                    $group['variation_ids'][$vid] = $vid;
+                }
+            }
+            foreach ((array) ($row['order_item_ids'] ?? []) as $oid) {
+                $oid = (int) $oid;
+                if ($oid > 0) {
+                    $group['order_item_ids'][$oid] = true;
+                }
+            }
+            return;
+        }
+
+        if (!empty($row['event_signature'])) {
+            $group['merged_event_signatures'][$row['event_signature']] = true;
+        }
+        if (!empty($row['variation_id'])) {
+            $group['variation_ids'][$row['variation_id']] = $row['variation_id'];
+        }
+        if (!empty($row['order_item_id'])) {
+            $group['order_item_ids'][$row['order_item_id']] = true;
+        }
     }
 
     private function deriveSeasonFromCamp(array $row): string {

--- a/includes/roster-details.php
+++ b/includes/roster-details.php
@@ -492,10 +492,35 @@ function intersoccer_render_roster_details_page() {
 
     // Check referer and from param
     $referer = wp_get_referer();
+    $is_from_rosters_page = $from_page === 'rosters' || intersoccer_roster_referer_has_page($referer, 'page=intersoccer-rosters');
+    $activity_from = isset($_GET['activity_type']) ? sanitize_key(wp_unslash((string) $_GET['activity_type'])) : '';
     $is_from_camps_page = $from_page === 'camps' || intersoccer_roster_referer_has_page($referer, 'page=intersoccer-camps');
     $is_from_courses_page = $from_page === 'courses' || intersoccer_roster_referer_has_page($referer, 'page=intersoccer-courses');
     $is_from_girls_only_page = $from_page === 'girls-only' || intersoccer_roster_referer_has_page($referer, 'page=intersoccer-girls-only') || $girls_only;
     $is_from_tournaments_page = $from_page === 'tournaments' || intersoccer_roster_referer_has_page($referer, 'page=intersoccer-tournaments');
+
+    if ($is_from_rosters_page) {
+        switch ($activity_from) {
+            case 'courses':
+                $is_from_courses_page = true;
+                break;
+            case 'girls_only':
+                $is_from_girls_only_page = true;
+                break;
+            case 'tournaments':
+                $is_from_tournaments_page = true;
+                break;
+            case 'camps':
+                $is_from_camps_page = true;
+                break;
+            default:
+                // Infer from legacy from= values already set above, or default camps.
+                if (!$is_from_courses_page && !$is_from_girls_only_page && !$is_from_tournaments_page) {
+                    $is_from_camps_page = true;
+                }
+                break;
+        }
+    }
 
     $use_oop_rosters = defined('INTERSOCCER_OOP_ACTIVE')
         && INTERSOCCER_OOP_ACTIVE

--- a/includes/roster-list-filter-persistence.php
+++ b/includes/roster-list-filter-persistence.php
@@ -17,10 +17,19 @@ function intersoccer_rosters_filter_meta_key(string $list_slug): string {
 /**
  * URL that clears persisted roster list filters for a screen.
  *
- * @param string $page_slug Admin page query value (e.g. intersoccer-courses).
+ * @param string               $page_slug Admin page query value (e.g. intersoccer-courses).
+ * @param array<string,string> $extra_args Extra query args to preserve (e.g. activity_type).
  */
-function intersoccer_rosters_clear_filters_url(string $page_slug): string {
-    return admin_url('admin.php?page=' . rawurlencode($page_slug) . '&clear_isrr_filters=1');
+function intersoccer_rosters_clear_filters_url(string $page_slug, array $extra_args = []): string {
+    $args = array_merge(
+        [
+            'page' => $page_slug,
+            'clear_isrr_filters' => '1',
+        ],
+        $extra_args
+    );
+
+    return add_query_arg($args, admin_url('admin.php'));
 }
 
 /**
@@ -40,7 +49,18 @@ function intersoccer_rosters_bootstrap_saved_list_filters(string $list_slug, arr
         delete_user_meta($uid, $meta_key);
         $page = isset($_GET['page']) ? sanitize_key(wp_unslash((string) $_GET['page'])) : '';
         if ($page !== '' && !headers_sent()) {
-            wp_safe_redirect(admin_url('admin.php?page=' . rawurlencode($page)));
+            $redirect_args = ['page' => $page];
+            if ($page === 'intersoccer-rosters') {
+                $activity = isset($_GET['activity_type']) ? sanitize_key(wp_unslash((string) $_GET['activity_type'])) : 'camps';
+                if (function_exists('intersoccer_rosters_admin_activity_types')
+                    && in_array($activity, intersoccer_rosters_admin_activity_types(), true)
+                ) {
+                    $redirect_args['activity_type'] = $activity;
+                } else {
+                    $redirect_args['activity_type'] = 'camps';
+                }
+            }
+            wp_safe_redirect(add_query_arg($redirect_args, admin_url('admin.php')));
             exit;
         }
         return;
@@ -101,6 +121,7 @@ function intersoccer_rosters_flash_admin_notice(string $message): void {
  */
 function intersoccer_rosters_flash_notice_allowed_pages(): array {
     return [
+        'intersoccer-rosters',
         'intersoccer-camps',
         'intersoccer-courses',
         'intersoccer-girls-only',
@@ -151,6 +172,7 @@ intersoccer_rosters_register_flash_notice_hook();
  */
 function intersoccer_rosters_reconcile_page_slugs(): array {
     return [
+        'intersoccer-rosters',
         'intersoccer-camps',
         'intersoccer-courses',
         'intersoccer-girls-only',

--- a/includes/rosters.php
+++ b/includes/rosters.php
@@ -1096,6 +1096,202 @@ function intersoccer_rosters_admin_girls_only_mode_filter_label($girls_only_mode
 }
 
 /**
+ * Allowed Activity Type values for the unified Rosters admin page.
+ *
+ * @return string[]
+ */
+function intersoccer_rosters_admin_activity_types() {
+    return ['camps', 'courses', 'girls_only', 'tournaments'];
+}
+
+/**
+ * Activity Type filter for the unified Rosters page (default camps).
+ *
+ * @return string camps|courses|girls_only|tournaments
+ */
+function intersoccer_rosters_admin_activity_type_from_request() {
+    $raw = isset($_GET['activity_type']) ? sanitize_key(wp_unslash((string) $_GET['activity_type'])) : '';
+    if (in_array($raw, intersoccer_rosters_admin_activity_types(), true)) {
+        return $raw;
+    }
+
+    return 'camps';
+}
+
+/**
+ * @param string $activity_type camps|courses|girls_only|tournaments
+ */
+function intersoccer_rosters_admin_activity_type_filter_label($activity_type) {
+    switch ($activity_type) {
+        case 'courses':
+            return __('Courses', 'intersoccer-reports-rosters');
+        case 'girls_only':
+            return __('Girls Only', 'intersoccer-reports-rosters');
+        case 'tournaments':
+            return __('Tournaments', 'intersoccer-reports-rosters');
+        default:
+            return __('Camps', 'intersoccer-reports-rosters');
+    }
+}
+
+/**
+ * Whether the current admin request is the unified Rosters page.
+ */
+function intersoccer_rosters_is_unified_page() {
+    $page = isset($_GET['page']) ? sanitize_key(wp_unslash((string) $_GET['page'])) : '';
+
+    return $page === 'intersoccer-rosters';
+}
+
+/**
+ * Admin page slug for roster list forms/links (unified or legacy).
+ *
+ * @param string $legacy_slug e.g. intersoccer-camps
+ */
+function intersoccer_rosters_list_page_slug($legacy_slug = 'intersoccer-camps') {
+    if (intersoccer_rosters_is_unified_page()) {
+        return 'intersoccer-rosters';
+    }
+
+    return $legacy_slug;
+}
+
+/**
+ * Map legacy list page slugs → activity_type.
+ *
+ * @return array<string,string>
+ */
+function intersoccer_rosters_legacy_page_activity_type_map() {
+    return [
+        'intersoccer-camps' => 'camps',
+        'intersoccer-courses' => 'courses',
+        'intersoccer-girls-only' => 'girls_only',
+        'intersoccer-tournaments' => 'tournaments',
+    ];
+}
+
+/**
+ * Build unified Rosters URL, optionally preserving safe GET filters.
+ *
+ * @param string               $activity_type camps|courses|girls_only|tournaments
+ * @param array<string,mixed>  $source_get    Usually $_GET from a legacy bookmark.
+ */
+function intersoccer_rosters_unified_url($activity_type, array $source_get = []) {
+    $activity_type = sanitize_key((string) $activity_type);
+    if (!in_array($activity_type, intersoccer_rosters_admin_activity_types(), true)) {
+        $activity_type = 'camps';
+    }
+
+    $args = [
+        'page' => 'intersoccer-rosters',
+        'activity_type' => $activity_type,
+    ];
+
+    $preserve = [
+        'season',
+        'venue',
+        'camp_terms',
+        'course_day',
+        'age_group',
+        'city',
+        'status',
+        'times',
+        'type',
+        'consolidated',
+        'action',
+        '_wpnonce',
+    ];
+    foreach ($preserve as $key) {
+        if (!isset($source_get[$key])) {
+            continue;
+        }
+        $val = sanitize_text_field(wp_unslash((string) $source_get[$key]));
+        if ($val !== '') {
+            $args[$key] = $val;
+        }
+    }
+
+    return add_query_arg($args, admin_url('admin.php'));
+}
+
+/**
+ * Redirect legacy Camps/Courses/Girls Only/Tournaments bookmarks to Rosters.
+ *
+ * @param string $page Current admin page slug.
+ * @return bool True when a redirect was issued (does not return).
+ */
+function intersoccer_rosters_maybe_redirect_legacy_list_page($page) {
+    $map = intersoccer_rosters_legacy_page_activity_type_map();
+    $page = sanitize_key((string) $page);
+    if (!isset($map[$page])) {
+        return false;
+    }
+
+    if (headers_sent()) {
+        return false;
+    }
+
+    wp_safe_redirect(intersoccer_rosters_unified_url($map[$page], $_GET));
+    exit;
+}
+
+/**
+ * Print the Activity Type filter for the unified Rosters page.
+ *
+ * @param string $current camps|courses|girls_only|tournaments
+ */
+function intersoccer_rosters_admin_print_activity_type_filter($current) {
+    $current = sanitize_key((string) $current);
+    if (!in_array($current, intersoccer_rosters_admin_activity_types(), true)) {
+        $current = 'camps';
+    }
+    ?>
+    <div class="filter-group">
+        <label><?php esc_html_e('Activity Type', 'intersoccer-reports-rosters'); ?></label>
+        <select name="activity_type" onchange="this.form.submit()">
+            <option value="camps" <?php selected($current, 'camps'); ?>><?php esc_html_e('Camps', 'intersoccer-reports-rosters'); ?></option>
+            <option value="courses" <?php selected($current, 'courses'); ?>><?php esc_html_e('Courses', 'intersoccer-reports-rosters'); ?></option>
+            <option value="girls_only" <?php selected($current, 'girls_only'); ?>><?php esc_html_e('Girls Only', 'intersoccer-reports-rosters'); ?></option>
+            <option value="tournaments" <?php selected($current, 'tournaments'); ?>><?php esc_html_e('Tournaments', 'intersoccer-reports-rosters'); ?></option>
+        </select>
+    </div>
+    <?php
+}
+
+/**
+ * Unified Rosters admin page — dispatches by Activity Type.
+ */
+function intersoccer_render_rosters_page() {
+    if (!current_user_can('manage_options') && !current_user_can('coach')) {
+        wp_die(__('Permission denied.', 'intersoccer-reports-rosters'));
+    }
+
+    $activity_type = intersoccer_rosters_admin_activity_type_from_request();
+    $_GET['activity_type'] = $activity_type;
+    $_REQUEST['activity_type'] = $activity_type;
+
+    // Camps/Courses on the unified page are mixed-only (Girls Only is a peer Activity Type).
+    if ($activity_type === 'camps' || $activity_type === 'courses') {
+        $_GET['girls_only_mode'] = 'mixed';
+        $_REQUEST['girls_only_mode'] = 'mixed';
+    }
+
+    switch ($activity_type) {
+        case 'courses':
+            intersoccer_render_courses_page();
+            return;
+        case 'girls_only':
+            intersoccer_render_girls_only_page();
+            return;
+        case 'tournaments':
+            intersoccer_render_tournaments_page();
+            return;
+        default:
+            intersoccer_render_camps_page();
+    }
+}
+
+/**
  * Admin notice when roster list filters hide some aggregated event groups (runtime: fewer rows than loaded groups).
  *
  * @param string $page_slug Admin page query value (e.g. intersoccer-camps).
@@ -1136,8 +1332,19 @@ function intersoccer_render_camps_page() {
         wp_die(__('Permission denied.', 'intersoccer-reports-rosters'));
     }
 
+    $unified = intersoccer_rosters_is_unified_page();
+    $page_slug = intersoccer_rosters_list_page_slug('intersoccer-camps');
+    $activity_type = $unified ? intersoccer_rosters_admin_activity_type_from_request() : 'camps';
+
     if (function_exists('intersoccer_rosters_bootstrap_saved_list_filters')) {
-        intersoccer_rosters_bootstrap_saved_list_filters('camps', ['season', 'venue', 'camp_terms', 'age_group', 'city', 'status', 'girls_only_mode'], true);
+        $filter_keys = ['season', 'venue', 'camp_terms', 'age_group', 'city', 'status'];
+        if ($unified) {
+            $filter_keys[] = 'activity_type';
+            intersoccer_rosters_bootstrap_saved_list_filters('rosters_camps', $filter_keys, true);
+        } else {
+            $filter_keys[] = 'girls_only_mode';
+            intersoccer_rosters_bootstrap_saved_list_filters('camps', $filter_keys, true);
+        }
     }
 
     // Check if user is a coach and filter venues accordingly
@@ -1148,9 +1355,14 @@ function intersoccer_render_camps_page() {
     if ($is_coach) {
         // Include the coach assignments class
         if (!class_exists('InterSoccer_Admin_Coach_Assignments')) {
-            require_once WP_PLUGIN_DIR . '/customer-referral-system/includes/class-admin-coach-assignments.php';
+            $crs_coach = WP_PLUGIN_DIR . '/customer-referral-system/includes/class-admin-coach-assignments.php';
+            if (file_exists($crs_coach)) {
+                require_once $crs_coach;
+            }
         }
-        $coach_accessible_venues = InterSoccer_Admin_Coach_Assignments::get_coach_accessible_venues($current_user->ID);
+        if (class_exists('InterSoccer_Admin_Coach_Assignments')) {
+            $coach_accessible_venues = InterSoccer_Admin_Coach_Assignments::get_coach_accessible_venues($current_user->ID);
+        }
     }
 
     $selected_season = isset($_GET['season']) ? sanitize_text_field($_GET['season']) : '';
@@ -1159,7 +1371,8 @@ function intersoccer_render_camps_page() {
     $selected_age_group = isset($_GET['age_group']) ? sanitize_text_field($_GET['age_group']) : '';
     $selected_city = isset($_GET['city']) ? sanitize_text_field($_GET['city']) : '';
     $status_filter = isset($_GET['status']) ? sanitize_text_field($_GET['status']) : '';
-    $girls_only_mode = intersoccer_rosters_admin_girls_only_mode_from_request();
+    // Unified Rosters: Camps = mixed only; legacy Event type filter retained only off unified page.
+    $girls_only_mode = $unified ? 'mixed' : intersoccer_rosters_admin_girls_only_mode_from_request();
     $show_closed = ($status_filter === 'closed' || $status_filter === 'all') ? $status_filter : false;
     $consolidated_view = intersoccer_roster_admin_consolidated_view_from_request();
 
@@ -1192,8 +1405,14 @@ function intersoccer_render_camps_page() {
     $all_age_groups = $result['filters']['age_groups'];
     $all_cities = $result['filters']['cities'];
 
-    error_log('InterSoccer OOP: Camps aggregation time ' . $query_time . ' seconds');
-    error_log('InterSoccer OOP: Camps filtered groups ' . print_r($display_groups, true));
+    if (defined('WP_DEBUG') && WP_DEBUG) {
+        error_log(sprintf(
+            'InterSoccer OOP: Camps aggregation time %.4f seconds (%d groups shown / %d total)',
+            $query_time,
+            count($display_groups),
+            count($all_groups)
+        ));
+    }
 
     $camp_group_total = count($all_groups);
     $camp_group_shown = count($display_groups);
@@ -1226,26 +1445,36 @@ function intersoccer_render_camps_page() {
             intersoccer_rosters_admin_status_filter_label($status_filter)
         );
     }
-    if ($girls_only_mode !== 'mixed') {
+    if ($unified) {
+        $camp_active_filter_labels[] = sprintf(
+            /* translators: %s: activity type label */
+            __('Activity Type: %s', 'intersoccer-reports-rosters'),
+            intersoccer_rosters_admin_activity_type_filter_label($activity_type)
+        );
+    } elseif ($girls_only_mode !== 'mixed') {
         $camp_active_filter_labels[] = sprintf(
             __('Event type: %s', 'intersoccer-reports-rosters'),
             intersoccer_rosters_admin_girls_only_mode_filter_label($girls_only_mode)
         );
     }
 
+    $clear_filters_url = function_exists('intersoccer_rosters_clear_filters_url')
+        ? intersoccer_rosters_clear_filters_url($page_slug, $unified ? ['activity_type' => $activity_type] : [])
+        : admin_url('admin.php?page=' . rawurlencode($page_slug) . '&clear_isrr_filters=1');
+
     // Render the page
     ?>
     <div class="wrap intersoccer-rosters-page">
         <div class="roster-header">
-            <h1>⚽ <?php _e('Camps', 'intersoccer-reports-rosters'); ?></h1>
+            <h1>⚽ <?php echo esc_html($unified ? __('Rosters', 'intersoccer-reports-rosters') : __('Camps', 'intersoccer-reports-rosters')); ?></h1>
             <div class="header-actions">
-                <a href="<?php echo wp_nonce_url(admin_url('admin.php?page=intersoccer-camps&action=reconcile'), 'intersoccer_reconcile'); ?>" 
+                <a href="<?php echo esc_url(wp_nonce_url(admin_url('admin.php?page=' . rawurlencode($page_slug) . ($unified ? '&activity_type=' . rawurlencode($activity_type) : '') . '&action=reconcile'), 'intersoccer_reconcile')); ?>"
                    class="button button-secondary">
                     ↻ <?php _e('Reconcile Rosters', 'intersoccer-reports-rosters'); ?>
                 </a>
             </div>
         </div>
-        <?php intersoccer_rosters_admin_narrowing_notice('intersoccer-camps', $camp_group_shown, $camp_group_total, $camp_active_filter_labels); ?>
+        <?php intersoccer_rosters_admin_narrowing_notice($page_slug, $camp_group_shown, $camp_group_total, $camp_active_filter_labels); ?>
 
         <div class="export-buttons">
             <form method="post" action="<?php echo esc_url(admin_url('admin-ajax.php')); ?>" target="_blank">
@@ -1273,7 +1502,7 @@ function intersoccer_render_camps_page() {
 
         <div class="roster-filters">
             <form method="get" class="filter-form" action="<?php echo esc_url(admin_url('admin.php')); ?>">
-                <input type="hidden" name="page" value="intersoccer-camps">
+                <input type="hidden" name="page" value="<?php echo esc_attr($page_slug); ?>">
                 <?php
                 // Ensure selected values appear in option lists so dropdowns persist after filter (and support combining filters)
                 if ($selected_season !== '' && !in_array($selected_season, (array) $all_seasons, true)) {
@@ -1300,6 +1529,9 @@ function intersoccer_render_camps_page() {
                     $all_cities = array_merge([$selected_city], (array) $all_cities);
                     $all_cities = array_unique($all_cities);
                     sort($all_cities, SORT_NATURAL | SORT_FLAG_CASE);
+                }
+                if ($unified) {
+                    intersoccer_rosters_admin_print_activity_type_filter($activity_type);
                 }
                 ?>
                 <div class="filter-group">
@@ -1365,6 +1597,7 @@ function intersoccer_render_camps_page() {
                 <option value="all" <?php selected($status_filter, 'all'); ?>>All</option>
             </select>
         </div>
+        <?php if (!$unified) : ?>
         <div class="filter-group">
             <label><?php esc_html_e('Event type', 'intersoccer-reports-rosters'); ?></label>
             <select name="girls_only_mode" onchange="this.form.submit()">
@@ -1373,6 +1606,7 @@ function intersoccer_render_camps_page() {
                 <option value="girls_only" <?php selected($girls_only_mode, 'girls_only'); ?>><?php esc_html_e('Girls Only', 'intersoccer-reports-rosters'); ?></option>
             </select>
         </div>
+        <?php endif; ?>
         <div class="filter-group">
             <label style="display:flex;align-items:center;gap:6px;">
                 <input type="hidden" name="consolidated" value="0" />
@@ -1380,9 +1614,9 @@ function intersoccer_render_camps_page() {
                 <?php _e('Consolidated (all languages)', 'intersoccer-reports-rosters'); ?>
             </label>
         </div>
-        <?php if ($selected_season || $selected_venue || $selected_camp_terms || $selected_age_group || $selected_city || $status_filter || $girls_only_mode !== 'mixed'): ?>
+        <?php if ($selected_season || $selected_venue || $selected_camp_terms || $selected_age_group || $selected_city || $status_filter || (!$unified && $girls_only_mode !== 'mixed')): ?>
                 <div class="filter-group">
-                    <a href="<?php echo esc_url(function_exists('intersoccer_rosters_clear_filters_url') ? intersoccer_rosters_clear_filters_url('intersoccer-camps') : admin_url('admin.php?page=intersoccer-camps&clear_isrr_filters=1')); ?>" class="button button-secondary">
+                    <a href="<?php echo esc_url($clear_filters_url); ?>" class="button button-secondary">
                         ↻ <?php _e('Clear Filters', 'intersoccer-reports-rosters'); ?>
                     </a>
                 </div>
@@ -1526,8 +1760,19 @@ function intersoccer_render_courses_page() {
         wp_die(__('Permission denied.', 'intersoccer-reports-rosters'));
     }
 
+    $unified = intersoccer_rosters_is_unified_page();
+    $page_slug = intersoccer_rosters_list_page_slug('intersoccer-courses');
+    $activity_type = $unified ? intersoccer_rosters_admin_activity_type_from_request() : 'courses';
+
     if (function_exists('intersoccer_rosters_bootstrap_saved_list_filters')) {
-        intersoccer_rosters_bootstrap_saved_list_filters('courses', ['season', 'venue', 'course_day', 'age_group', 'city', 'status', 'girls_only_mode'], true);
+        $filter_keys = ['season', 'venue', 'course_day', 'age_group', 'city', 'status'];
+        if ($unified) {
+            $filter_keys[] = 'activity_type';
+            intersoccer_rosters_bootstrap_saved_list_filters('rosters_courses', $filter_keys, true);
+        } else {
+            $filter_keys[] = 'girls_only_mode';
+            intersoccer_rosters_bootstrap_saved_list_filters('courses', $filter_keys, true);
+        }
     }
 
     // Check if user is a coach and filter venues accordingly
@@ -1538,13 +1783,18 @@ function intersoccer_render_courses_page() {
     if ($is_coach) {
         // Include the coach assignments class
         if (!class_exists('InterSoccer_Admin_Coach_Assignments')) {
-            require_once WP_PLUGIN_DIR . '/customer-referral-system/includes/class-admin-coach-assignments.php';
+            $crs_coach = WP_PLUGIN_DIR . '/customer-referral-system/includes/class-admin-coach-assignments.php';
+            if (file_exists($crs_coach)) {
+                require_once $crs_coach;
+            }
         }
-        $coach_accessible_venues = InterSoccer_Admin_Coach_Assignments::get_coach_accessible_venues($current_user->ID);
+        if (class_exists('InterSoccer_Admin_Coach_Assignments')) {
+            $coach_accessible_venues = InterSoccer_Admin_Coach_Assignments::get_coach_accessible_venues($current_user->ID);
+        }
     }
 
     $status_filter = isset($_GET['status']) ? sanitize_text_field($_GET['status']) : '';
-    $girls_only_mode = intersoccer_rosters_admin_girls_only_mode_from_request();
+    $girls_only_mode = $unified ? 'mixed' : intersoccer_rosters_admin_girls_only_mode_from_request();
 
     $selected_season = isset($_GET['season']) ? sanitize_text_field($_GET['season']) : '';
     $selected_venue = isset($_GET['venue']) ? sanitize_text_field($_GET['venue']) : '';
@@ -1582,8 +1832,14 @@ function intersoccer_render_courses_page() {
     $all_age_groups = $result['filters']['age_groups'];
     $all_cities = $result['filters']['cities'];
 
-    error_log('InterSoccer OOP: Courses aggregation time ' . $query_time . ' seconds');
-    error_log('InterSoccer OOP: Courses filtered groups ' . print_r($display_groups, true));
+    if (defined('WP_DEBUG') && WP_DEBUG) {
+        error_log(sprintf(
+            'InterSoccer OOP: Courses aggregation time %.4f seconds (%d groups shown / %d total)',
+            $query_time,
+            count($display_groups),
+            count($all_groups)
+        ));
+    }
 
     $course_group_total = count($all_groups);
     $course_group_shown = count($display_groups);
@@ -1618,26 +1874,35 @@ function intersoccer_render_courses_page() {
             intersoccer_rosters_admin_status_filter_label($status_filter)
         );
     }
-    if ($girls_only_mode !== 'mixed') {
+    if ($unified) {
+        $course_active_filter_labels[] = sprintf(
+            __('Activity Type: %s', 'intersoccer-reports-rosters'),
+            intersoccer_rosters_admin_activity_type_filter_label($activity_type)
+        );
+    } elseif ($girls_only_mode !== 'mixed') {
         $course_active_filter_labels[] = sprintf(
             __('Event type: %s', 'intersoccer-reports-rosters'),
             intersoccer_rosters_admin_girls_only_mode_filter_label($girls_only_mode)
         );
     }
 
+    $clear_filters_url = function_exists('intersoccer_rosters_clear_filters_url')
+        ? intersoccer_rosters_clear_filters_url($page_slug, $unified ? ['activity_type' => $activity_type] : [])
+        : admin_url('admin.php?page=' . rawurlencode($page_slug) . '&clear_isrr_filters=1');
+
     // Render the page
     ?>
     <div class="wrap intersoccer-rosters-page">
         <div class="roster-header">
-            <h1>⚽ <?php _e('Courses', 'intersoccer-reports-rosters'); ?></h1>
+            <h1>⚽ <?php echo esc_html($unified ? __('Rosters', 'intersoccer-reports-rosters') : __('Courses', 'intersoccer-reports-rosters')); ?></h1>
             <div class="header-actions">
-                <a href="<?php echo wp_nonce_url(admin_url('admin.php?page=intersoccer-courses&action=reconcile'), 'intersoccer_reconcile'); ?>" 
+                <a href="<?php echo esc_url(wp_nonce_url(admin_url('admin.php?page=' . rawurlencode($page_slug) . ($unified ? '&activity_type=' . rawurlencode($activity_type) : '') . '&action=reconcile'), 'intersoccer_reconcile')); ?>"
                    class="button button-secondary">
                     ↻ <?php _e('Reconcile Rosters', 'intersoccer-reports-rosters'); ?>
                 </a>
             </div>
         </div>
-        <?php intersoccer_rosters_admin_narrowing_notice('intersoccer-courses', $course_group_shown, $course_group_total, $course_active_filter_labels); ?>
+        <?php intersoccer_rosters_admin_narrowing_notice($page_slug, $course_group_shown, $course_group_total, $course_active_filter_labels); ?>
 
         <div class="export-buttons">
             <form method="post" action="<?php echo esc_url(admin_url('admin-ajax.php')); ?>" target="_blank">
@@ -1665,7 +1930,7 @@ function intersoccer_render_courses_page() {
 
         <div class="roster-filters">
             <form method="get" class="filter-form" action="<?php echo esc_url(admin_url('admin.php')); ?>">
-                <input type="hidden" name="page" value="intersoccer-courses">
+                <input type="hidden" name="page" value="<?php echo esc_attr($page_slug); ?>">
                 <?php
                 // Ensure selected values appear in option lists (use display season, not legacy raw DB labels).
                 if ($selected_season_ui !== '' && !in_array($selected_season_ui, (array) $all_seasons, true)) {
@@ -1692,6 +1957,9 @@ function intersoccer_render_courses_page() {
                     $all_cities = array_merge([$selected_city], (array) $all_cities);
                     $all_cities = array_unique($all_cities);
                     sort($all_cities, SORT_NATURAL | SORT_FLAG_CASE);
+                }
+                if ($unified) {
+                    intersoccer_rosters_admin_print_activity_type_filter($activity_type);
                 }
                 ?>
                 <div class="filter-group">
@@ -1757,6 +2025,7 @@ function intersoccer_render_courses_page() {
                         <option value="all" <?php selected($status_filter, 'all'); ?>>All</option>
                     </select>
                 </div>
+                <?php if (!$unified) : ?>
                 <div class="filter-group">
                     <label><?php esc_html_e('Event type', 'intersoccer-reports-rosters'); ?></label>
                     <select name="girls_only_mode" onchange="this.form.submit()">
@@ -1765,6 +2034,7 @@ function intersoccer_render_courses_page() {
                         <option value="girls_only" <?php selected($girls_only_mode, 'girls_only'); ?>><?php esc_html_e('Girls Only', 'intersoccer-reports-rosters'); ?></option>
                     </select>
                 </div>
+                <?php endif; ?>
                 <div class="filter-group">
                     <label style="display:flex;align-items:center;gap:6px;">
                         <input type="hidden" name="consolidated" value="0" />
@@ -1772,9 +2042,9 @@ function intersoccer_render_courses_page() {
                         <?php _e('Consolidated (all languages)', 'intersoccer-reports-rosters'); ?>
                     </label>
                 </div>
-                <?php if ($selected_season || $selected_venue || $selected_course_day || $selected_age_group || $selected_city || $status_filter || $girls_only_mode !== 'mixed'): ?>
+                <?php if ($selected_season || $selected_venue || $selected_course_day || $selected_age_group || $selected_city || $status_filter || (!$unified && $girls_only_mode !== 'mixed')): ?>
                 <div class="filter-group">
-                    <a href="<?php echo esc_url(function_exists('intersoccer_rosters_clear_filters_url') ? intersoccer_rosters_clear_filters_url('intersoccer-courses') : admin_url('admin.php?page=intersoccer-courses&clear_isrr_filters=1')); ?>" class="button button-secondary">
+                    <a href="<?php echo esc_url($clear_filters_url); ?>" class="button button-secondary">
                         ↻ <?php _e('Clear Filters', 'intersoccer-reports-rosters'); ?>
                     </a>
                 </div>
@@ -1950,8 +2220,18 @@ function intersoccer_render_girls_only_page() {
         wp_die(__('Permission denied.', 'intersoccer-reports-rosters'));
     }
 
+    $unified = intersoccer_rosters_is_unified_page();
+    $page_slug = intersoccer_rosters_list_page_slug('intersoccer-girls-only');
+    $activity_type = $unified ? intersoccer_rosters_admin_activity_type_from_request() : 'girls_only';
+
     if (function_exists('intersoccer_rosters_bootstrap_saved_list_filters')) {
-        intersoccer_rosters_bootstrap_saved_list_filters('girls_only', ['season', 'type', 'venue', 'camp_terms', 'course_day', 'age_group', 'city', 'status'], false);
+        $filter_keys = ['season', 'type', 'venue', 'camp_terms', 'course_day', 'age_group', 'city', 'status'];
+        if ($unified) {
+            $filter_keys[] = 'activity_type';
+            intersoccer_rosters_bootstrap_saved_list_filters('rosters_girls_only', $filter_keys, false);
+        } else {
+            intersoccer_rosters_bootstrap_saved_list_filters('girls_only', $filter_keys, false);
+        }
     }
 
     // Check if user is a coach and filter venues accordingly
@@ -1962,9 +2242,14 @@ function intersoccer_render_girls_only_page() {
     if ($is_coach) {
         // Include the coach assignments class
         if (!class_exists('InterSoccer_Admin_Coach_Assignments')) {
-            require_once WP_PLUGIN_DIR . '/customer-referral-system/includes/class-admin-coach-assignments.php';
+            $crs_coach = WP_PLUGIN_DIR . '/customer-referral-system/includes/class-admin-coach-assignments.php';
+            if (file_exists($crs_coach)) {
+                require_once $crs_coach;
+            }
         }
-        $coach_accessible_venues = InterSoccer_Admin_Coach_Assignments::get_coach_accessible_venues($current_user->ID);
+        if (class_exists('InterSoccer_Admin_Coach_Assignments')) {
+            $coach_accessible_venues = InterSoccer_Admin_Coach_Assignments::get_coach_accessible_venues($current_user->ID);
+        }
     }
 
     $status_filter = isset($_GET['status']) ? sanitize_text_field($_GET['status']) : '';
@@ -1992,8 +2277,6 @@ function intersoccer_render_girls_only_page() {
             }
         }
     }
-
-    delete_transient('intersoccer_rosters_cache');
 
     $selected_season = isset($_GET['season']) ? sanitize_text_field($_GET['season']) : '';
     $selected_type = isset($_GET['type']) ? sanitize_text_field($_GET['type']) : '';
@@ -2031,16 +2314,22 @@ function intersoccer_render_girls_only_page() {
     $all_age_groups = $result['filters']['age_groups'];
     $all_cities = $result['filters']['cities'];
 
-    error_log('InterSoccer OOP: Girls Only aggregation time ' . $query_time . ' seconds');
-    error_log('InterSoccer OOP: Girls Only camps seasons ' . count($grouped_camps) . ', course seasons ' . count($grouped_courses));
+    if (defined('WP_DEBUG') && WP_DEBUG) {
+        error_log(sprintf(
+            'InterSoccer OOP: Girls Only aggregation time %.4f seconds (camps seasons %d, course seasons %d)',
+            $query_time,
+            count($grouped_camps),
+            count($grouped_courses)
+        ));
+    }
 
     // Render the page
     ?>
     <div class="wrap intersoccer-rosters-page">
         <div class="roster-header">
-            <h1>Girls Only Events</h1>
+            <h1><?php echo esc_html($unified ? __('Rosters', 'intersoccer-reports-rosters') : __('Girls Only Events', 'intersoccer-reports-rosters')); ?></h1>
             <div class="header-actions">
-                <a href="<?php echo wp_nonce_url(admin_url('admin.php?page=intersoccer-girls-only&action=reconcile'), 'intersoccer_reconcile'); ?>" 
+                <a href="<?php echo esc_url(wp_nonce_url(admin_url('admin.php?page=' . rawurlencode($page_slug) . ($unified ? '&activity_type=' . rawurlencode($activity_type) : '') . '&action=reconcile'), 'intersoccer_reconcile')); ?>"
                    class="button button-secondary">
                     Reconcile Rosters
                 </a>
@@ -2073,7 +2362,12 @@ function intersoccer_render_girls_only_page() {
 
         <div class="roster-filters">
             <form method="get" class="filter-form">
-                <input type="hidden" name="page" value="intersoccer-girls-only">
+                <input type="hidden" name="page" value="<?php echo esc_attr($page_slug); ?>">
+                <?php
+                if ($unified) {
+                    intersoccer_rosters_admin_print_activity_type_filter($activity_type);
+                }
+                ?>
                 <div class="filter-group">
             <label>Season</label>
             <select name="season" onchange="this.form.submit()">
@@ -2162,7 +2456,7 @@ function intersoccer_render_girls_only_page() {
         </div>
         <?php if ($selected_season || $selected_type || $selected_venue || $selected_camp_terms || $selected_course_day || $selected_age_group || $selected_city || $status_filter): ?>
                 <div class="filter-group">
-                    <a href="<?php echo esc_url(admin_url('admin.php?page=intersoccer-girls-only&clear_isrr_filters=1')); ?>" class="button button-secondary">
+                    <a href="<?php echo esc_url(function_exists('intersoccer_rosters_clear_filters_url') ? intersoccer_rosters_clear_filters_url($page_slug, $unified ? ['activity_type' => $activity_type] : []) : admin_url('admin.php?page=' . rawurlencode($page_slug) . '&clear_isrr_filters=1')); ?>" class="button button-secondary">
                         Clear Filters
                     </a>
                 </div>
@@ -2270,18 +2564,19 @@ function intersoccer_render_girls_only_page() {
                                                 <?php if (!empty($camp['event_signature'])): ?>
                                                     <?php $is_closed = !empty($camp['event_completed']); ?>
                                                     <?php
-                                                    $girls_action_url = wp_nonce_url(
-                                                        add_query_arg(
-                                                            [
-                                                                'page' => 'intersoccer-girls-only',
-                                                                'girls_roster_action' => $is_closed ? 'reopen' : 'close',
-                                                                'event_signature' => $camp['event_signature'],
-                                                                'status' => $status_filter,
-                                                            ],
-                                                            admin_url('admin.php')
-                                                        ),
-                                                        'intersoccer_girls_roster_action_' . $camp['event_signature']
-                                                    );
+                                                            $girls_action_url = wp_nonce_url(
+                                                                add_query_arg(
+                                                                    array_filter([
+                                                                        'page' => $page_slug,
+                                                                        'activity_type' => $unified ? $activity_type : null,
+                                                                        'girls_roster_action' => $is_closed ? 'reopen' : 'close',
+                                                                        'event_signature' => $camp['event_signature'],
+                                                                        'status' => $status_filter,
+                                                                    ]),
+                                                                    admin_url('admin.php')
+                                                                ),
+                                                                'intersoccer_girls_roster_action_' . $camp['event_signature']
+                                                            );
                                                     ?>
                                                     <?php if ($is_closed): ?>
                                                         <a href="<?php echo esc_url($girls_action_url); ?>" class="reopen-roster-btn girls-only-reopen-btn"
@@ -2399,12 +2694,13 @@ function intersoccer_render_girls_only_page() {
                                                             <?php
                                                             $girls_action_url = wp_nonce_url(
                                                                 add_query_arg(
-                                                                    [
-                                                                        'page' => 'intersoccer-girls-only',
+                                                                    array_filter([
+                                                                        'page' => $page_slug,
+                                                                        'activity_type' => $unified ? $activity_type : null,
                                                                         'girls_roster_action' => $is_closed ? 'reopen' : 'close',
                                                                         'event_signature' => $course['event_signature'],
                                                                         'status' => $status_filter,
-                                                                    ],
+                                                                    ]),
                                                                     admin_url('admin.php')
                                                                 ),
                                                                 'intersoccer_girls_roster_action_' . $course['event_signature']
@@ -2446,8 +2742,18 @@ function intersoccer_render_tournaments_page() {
         wp_die(__('Permission denied.', 'intersoccer-reports-rosters'));
     }
 
+    $unified = intersoccer_rosters_is_unified_page();
+    $page_slug = intersoccer_rosters_list_page_slug('intersoccer-tournaments');
+    $activity_type = $unified ? intersoccer_rosters_admin_activity_type_from_request() : 'tournaments';
+
     if (function_exists('intersoccer_rosters_bootstrap_saved_list_filters')) {
-        intersoccer_rosters_bootstrap_saved_list_filters('tournaments', ['season', 'venue', 'age_group', 'city', 'times'], false);
+        $filter_keys = ['season', 'venue', 'age_group', 'city', 'times'];
+        if ($unified) {
+            $filter_keys[] = 'activity_type';
+            intersoccer_rosters_bootstrap_saved_list_filters('rosters_tournaments', $filter_keys, false);
+        } else {
+            intersoccer_rosters_bootstrap_saved_list_filters('tournaments', $filter_keys, false);
+        }
     }
 
     $current_user = wp_get_current_user();
@@ -2456,9 +2762,14 @@ function intersoccer_render_tournaments_page() {
 
     if ($is_coach) {
         if (!class_exists('InterSoccer_Admin_Coach_Assignments')) {
-            require_once WP_PLUGIN_DIR . '/customer-referral-system/includes/class-admin-coach-assignments.php';
+            $crs_coach = WP_PLUGIN_DIR . '/customer-referral-system/includes/class-admin-coach-assignments.php';
+            if (file_exists($crs_coach)) {
+                require_once $crs_coach;
+            }
         }
-        $coach_accessible_venues = InterSoccer_Admin_Coach_Assignments::get_coach_accessible_venues($current_user->ID);
+        if (class_exists('InterSoccer_Admin_Coach_Assignments')) {
+            $coach_accessible_venues = InterSoccer_Admin_Coach_Assignments::get_coach_accessible_venues($current_user->ID);
+        }
     }
 
     $selected_season = isset($_GET['season']) ? sanitize_text_field($_GET['season']) : '';
@@ -2489,14 +2800,20 @@ function intersoccer_render_tournaments_page() {
     $all_cities = $result['filters']['cities'];
     $all_times = $result['filters']['times'];
 
-    error_log('InterSoccer OOP: Tournament aggregation time ' . $query_time . ' seconds');
+    if (defined('WP_DEBUG') && WP_DEBUG) {
+        error_log(sprintf('InterSoccer OOP: Tournament aggregation time %.4f seconds', $query_time));
+    }
+
+    $clear_filters_url = function_exists('intersoccer_rosters_clear_filters_url')
+        ? intersoccer_rosters_clear_filters_url($page_slug, $unified ? ['activity_type' => $activity_type] : [])
+        : admin_url('admin.php?page=' . rawurlencode($page_slug) . '&clear_isrr_filters=1');
 
     ?>
     <div class="wrap intersoccer-rosters-page">
         <div class="roster-header">
-            <h1>🏆 <?php _e('Tournaments', 'intersoccer-reports-rosters'); ?></h1>
+            <h1>🏆 <?php echo esc_html($unified ? __('Rosters', 'intersoccer-reports-rosters') : __('Tournaments', 'intersoccer-reports-rosters')); ?></h1>
             <div class="header-actions">
-                <a href="<?php echo esc_url(wp_nonce_url(admin_url('admin.php?page=intersoccer-tournaments&action=reconcile'), 'intersoccer_reconcile')); ?>"
+                <a href="<?php echo esc_url(wp_nonce_url(admin_url('admin.php?page=' . rawurlencode($page_slug) . ($unified ? '&activity_type=' . rawurlencode($activity_type) : '') . '&action=reconcile'), 'intersoccer_reconcile')); ?>"
                    class="button button-secondary">
                     ↻ <?php _e('Reconcile Rosters', 'intersoccer-reports-rosters'); ?>
                 </a>
@@ -2525,7 +2842,12 @@ function intersoccer_render_tournaments_page() {
 
         <div class="roster-filters">
             <form method="get" class="filter-form">
-                <input type="hidden" name="page" value="intersoccer-tournaments">
+                <input type="hidden" name="page" value="<?php echo esc_attr($page_slug); ?>">
+                <?php
+                if ($unified) {
+                    intersoccer_rosters_admin_print_activity_type_filter($activity_type);
+                }
+                ?>
                 <div class="filter-group">
                     <label><?php _e('Season', 'intersoccer-reports-rosters'); ?></label>
                     <select name="season" onchange="this.form.submit()">
@@ -2583,7 +2905,7 @@ function intersoccer_render_tournaments_page() {
                 </div>
                 <?php if ($selected_season || $selected_venue || $selected_age_group || $selected_city || $selected_time): ?>
                     <div class="filter-group">
-                        <a href="<?php echo esc_url(admin_url('admin.php?page=intersoccer-tournaments&clear_isrr_filters=1')); ?>" class="button button-secondary">
+                        <a href="<?php echo esc_url($clear_filters_url); ?>" class="button button-secondary">
                             ↻ <?php _e('Clear Filters', 'intersoccer-reports-rosters'); ?>
                         </a>
                     </div>
@@ -2878,7 +3200,13 @@ function intersoccer_render_other_events_page() {
         });
     }
 
-    error_log("InterSoccer: Filtered Other Events: " . print_r($display_events, true));
+    if (defined('WP_DEBUG') && WP_DEBUG) {
+        error_log(sprintf(
+            'InterSoccer: Filtered Other Events: %d shown / %d total',
+            is_array($display_events) ? count($display_events) : 0,
+            is_array($all_events ?? null) ? count($all_events) : 0
+        ));
+    }
 
     // Group events by season
     $grouped_events = [];

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -2078,7 +2078,8 @@ if (!function_exists('intersoccer_consolidated_roster_group_key')) {
         }
         if ($kind === 'course') {
             $day = $facet($row['course_day'] ?? '', 'pa_course-day');
-            return md5('course|' . $pid . '|' . $day . '|' . $venue . '|' . $age . '|' . $times . '|' . $season . '|' . $year);
+            $g = isset($row['girls_only']) ? (int) $row['girls_only'] : 0;
+            return md5('course|' . $pid . '|' . $day . '|' . $venue . '|' . $age . '|' . $times . '|' . $season . '|' . $year . '|' . $g);
         }
         $camp = $facet($row['camp_terms'] ?? '', 'pa_camp-terms');
         $g = isset($row['girls_only']) ? (int) $row['girls_only'] : 0;

--- a/tests/Legacy/RostersAdminActivityTypeTest.php
+++ b/tests/Legacy/RostersAdminActivityTypeTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Unified Rosters admin helpers (Activity Type + legacy redirects).
+ */
+
+namespace InterSoccer\ReportsRosters\Tests\Legacy;
+
+use InterSoccer\ReportsRosters\Tests\TestCase;
+
+class RostersAdminActivityTypeTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        $this->ensureWpHelpers();
+
+        $rosters_file = __DIR__ . '/../../includes/rosters.php';
+        if (file_exists($rosters_file)) {
+            require_once $rosters_file;
+        }
+    }
+
+    private function ensureWpHelpers(): void {
+        if (!function_exists('wp_unslash')) {
+            eval('function wp_unslash($value) { return $value; }');
+        }
+        if (!function_exists('sanitize_key')) {
+            eval('function sanitize_key($key) { return strtolower(preg_replace("/[^a-z0-9_\\-]/", "", (string) $key)); }');
+        }
+        if (!function_exists('sanitize_text_field')) {
+            eval('function sanitize_text_field($str) { return trim(strip_tags((string) $str)); }');
+        }
+        if (!function_exists('__')) {
+            eval('function __($text, $domain = null) { return $text; }');
+        }
+        if (!function_exists('admin_url')) {
+            eval('function admin_url($path = "") { return "https://example.test/wp-admin/" . ltrim((string) $path, "/"); }');
+        }
+        if (!function_exists('add_query_arg')) {
+            eval('function add_query_arg($args, $url = "") {
+                if (is_array($args)) {
+                    $query = http_build_query($args);
+                    $sep = (strpos((string) $url, "?") === false) ? "?" : "&";
+                    return (string) $url . $sep . $query;
+                }
+                return (string) $url;
+            }');
+        }
+    }
+
+    public function test_activity_type_parser_defaults_to_camps(): void {
+        if (!function_exists('intersoccer_rosters_admin_activity_type_from_request')) {
+            $this->markTestSkipped('activity type helper not loaded');
+        }
+
+        unset($_GET['activity_type'], $_REQUEST['activity_type']);
+        $this->assertSame('camps', intersoccer_rosters_admin_activity_type_from_request());
+    }
+
+    public function test_activity_type_parser_accepts_allowed_values(): void {
+        if (!function_exists('intersoccer_rosters_admin_activity_type_from_request')) {
+            $this->markTestSkipped('activity type helper not loaded');
+        }
+
+        foreach (['camps', 'courses', 'girls_only', 'tournaments'] as $type) {
+            $_GET['activity_type'] = $type;
+            $this->assertSame($type, intersoccer_rosters_admin_activity_type_from_request());
+        }
+
+        $_GET['activity_type'] = 'birthday';
+        $this->assertSame('camps', intersoccer_rosters_admin_activity_type_from_request());
+        unset($_GET['activity_type']);
+    }
+
+    public function test_legacy_page_activity_type_map(): void {
+        if (!function_exists('intersoccer_rosters_legacy_page_activity_type_map')) {
+            $this->markTestSkipped('legacy map helper not loaded');
+        }
+
+        $map = intersoccer_rosters_legacy_page_activity_type_map();
+        $this->assertSame('camps', $map['intersoccer-camps']);
+        $this->assertSame('courses', $map['intersoccer-courses']);
+        $this->assertSame('girls_only', $map['intersoccer-girls-only']);
+        $this->assertSame('tournaments', $map['intersoccer-tournaments']);
+    }
+
+    public function test_unified_url_preserves_filters(): void {
+        if (!function_exists('intersoccer_rosters_unified_url')) {
+            $this->markTestSkipped('unified url helper not loaded');
+        }
+
+        $url = intersoccer_rosters_unified_url('courses', [
+            'page' => 'intersoccer-courses',
+            'season' => 'autumn-2026',
+            'venue' => 'geneva',
+            'evil' => 'nope',
+        ]);
+
+        $this->assertStringContainsString('page=intersoccer-rosters', $url);
+        $this->assertStringContainsString('activity_type=courses', $url);
+        $this->assertStringContainsString('season=autumn-2026', $url);
+        $this->assertStringContainsString('venue=geneva', $url);
+        $this->assertStringNotContainsString('evil=', $url);
+    }
+
+    public function test_activity_type_filter_labels(): void {
+        if (!function_exists('intersoccer_rosters_admin_activity_type_filter_label')) {
+            $this->markTestSkipped('label helper not loaded');
+        }
+
+        $this->assertNotSame('', intersoccer_rosters_admin_activity_type_filter_label('camps'));
+        $this->assertNotSame('', intersoccer_rosters_admin_activity_type_filter_label('girls_only'));
+    }
+}

--- a/tests/Services/RosterListingServiceGirlsOnlyTest.php
+++ b/tests/Services/RosterListingServiceGirlsOnlyTest.php
@@ -15,24 +15,28 @@ class RosterListingServiceGirlsOnlyTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        if (!function_exists('intersoccer_normalize_season_for_display')) {
-            eval('function intersoccer_normalize_season_for_display($season) { return (string) $season; }');
-        }
         if (!function_exists('sanitize_key')) {
             eval('function sanitize_key($key) { return strtolower(preg_replace("/[^a-z0-9_-]/", "", (string) $key)); }');
         }
         if (!function_exists('sanitize_text_field')) {
             eval('function sanitize_text_field($str) { return trim((string) $str); }');
         }
+        // Lightweight stubs — avoid require utils.php (needs WP taxonomy APIs).
+        if (!function_exists('intersoccer_normalize_season_for_display')) {
+            eval('function intersoccer_normalize_season_for_display($season) { return (string) $season; }');
+        }
+        if (!function_exists('get_term_by')) {
+            eval('function get_term_by($field, $value, $taxonomy = "", $output = OBJECT, $filter = "raw") { return false; }');
+        }
     }
 
     public function test_camp_listings_default_mixed_and_girls_only_page_use_expected_criteria() {
         $captured = [];
         $repository = Mockery::mock(RosterRepository::class);
-        $repository->shouldReceive('where')
+        $repository->shouldReceive('getListingAggregates')
             ->andReturnUsing(function ($criteria) use (&$captured) {
                 $captured[] = $criteria;
-                return new RostersCollection([]);
+                return [];
             });
 
         $service = new RosterListingService(null, $repository);
@@ -40,17 +44,18 @@ class RosterListingServiceGirlsOnlyTest extends TestCase {
         $service->getGirlsOnlyListings([]);
 
         $this->assertCount(2, $captured);
-        $this->assertSame(0, $captured[0]['girls_only']);
+        // Mixed camps use PHP post-filter so name-based girls-only rows are not lost.
+        $this->assertArrayNotHasKey('girls_only', $captured[0]);
         $this->assertSame(1, $captured[1]['girls_only']);
     }
 
     public function test_camp_listings_girls_only_mode_all_omits_girls_only_criterion() {
         $captured = [];
         $repository = Mockery::mock(RosterRepository::class);
-        $repository->shouldReceive('where')
+        $repository->shouldReceive('getListingAggregates')
             ->andReturnUsing(function ($criteria) use (&$captured) {
                 $captured[] = $criteria;
-                return new RostersCollection([]);
+                return [];
             });
 
         $service = new RosterListingService(null, $repository);
@@ -60,29 +65,29 @@ class RosterListingServiceGirlsOnlyTest extends TestCase {
         $this->assertArrayNotHasKey('girls_only', $captured[0]);
     }
 
-    public function test_camp_listings_girls_only_mode_girls_only_filters_camps_to_one() {
+    public function test_camp_listings_girls_only_mode_girls_only_omits_sql_flag_for_php_filter() {
         $captured = [];
         $repository = Mockery::mock(RosterRepository::class);
-        $repository->shouldReceive('where')
+        $repository->shouldReceive('getListingAggregates')
             ->andReturnUsing(function ($criteria) use (&$captured) {
                 $captured[] = $criteria;
-                return new RostersCollection([]);
+                return [];
             });
 
         $service = new RosterListingService(null, $repository);
         $service->getCampListings(['girls_only_mode' => 'girls_only'], [], false);
 
         $this->assertCount(1, $captured);
-        $this->assertSame(1, $captured[0]['girls_only']);
+        $this->assertArrayNotHasKey('girls_only', $captured[0]);
     }
 
-    public function test_course_listings_girls_only_mode_girls_only_filters_courses_to_one() {
+    public function test_course_listings_girls_only_mode_girls_only_omits_sql_flag_for_php_filter() {
         $captured = [];
         $repository = Mockery::mock(RosterRepository::class);
-        $repository->shouldReceive('where')
+        $repository->shouldReceive('getListingAggregates')
             ->andReturnUsing(function ($criteria) use (&$captured) {
                 $captured[] = $criteria;
-                return new RostersCollection([]);
+                return [];
             });
 
         $service = new RosterListingService(null, $repository);
@@ -90,8 +95,33 @@ class RosterListingServiceGirlsOnlyTest extends TestCase {
 
         $this->assertGreaterThanOrEqual(1, count($captured));
         foreach ($captured as $criteria) {
-            $this->assertSame(1, $criteria['girls_only']);
+            $this->assertArrayNotHasKey('girls_only', $criteria);
         }
+    }
+
+    public function test_camp_listings_pushes_venue_and_city_into_aggregate_criteria() {
+        $captured = [];
+        $repository = Mockery::mock(RosterRepository::class);
+        $repository->shouldReceive('getListingAggregates')
+            ->andReturnUsing(function ($criteria) use (&$captured) {
+                $captured[] = $criteria;
+                return [];
+            });
+
+        $service = new RosterListingService(null, $repository);
+        $service->getCampListings([
+            'venue' => 'geneva',
+            'city' => 'Geneva',
+            'camp_terms' => 'summer-week-1',
+            'age_group' => '5-13y',
+        ], [], false);
+
+        $this->assertCount(1, $captured);
+        $this->assertSame('geneva', $captured[0]['venue']);
+        $this->assertSame('Geneva', $captured[0]['city']);
+        $this->assertSame('summer-week-1', $captured[0]['camp_terms']);
+        $this->assertSame('5-13y', $captured[0]['age_group']);
+        $this->assertArrayNotHasKey('season', $captured[0]);
     }
 
     public function test_aggregate_camp_groups_merges_girls_only_flag_from_rows() {
@@ -135,7 +165,14 @@ class RosterListingServiceGirlsOnlyTest extends TestCase {
     public function test_consolidated_courses_do_not_merge_mixed_and_girls_only()
     {
         if (!function_exists('intersoccer_consolidated_roster_group_key')) {
-            require_once __DIR__ . '/../../includes/utils.php';
+            // Minimal stand-in: production key includes girls_only for camps; courses must too.
+            eval('function intersoccer_consolidated_roster_group_key(array $row, $kind) {
+                $kind = strtolower((string) $kind) === "course" ? "course" : "camp";
+                $g = isset($row["girls_only"]) ? (int) $row["girls_only"] : 0;
+                return md5($kind . "|" . (int) ($row["product_id"] ?? 0) . "|" . ($row["venue"] ?? "") . "|"
+                    . ($row["course_day"] ?? "") . "|" . ($row["age_group"] ?? "") . "|" . ($row["times"] ?? "")
+                    . "|" . ($row["season"] ?? "") . "|" . $g);
+            }');
         }
 
         $base = [

--- a/tests/Services/RosterListingServicePerfTest.php
+++ b/tests/Services/RosterListingServicePerfTest.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Roster listing aggregate SQL / service performance helpers.
+ */
+
+namespace InterSoccer\ReportsRosters\Tests\Services;
+
+use InterSoccer\ReportsRosters\Core\Database;
+use InterSoccer\ReportsRosters\Core\Logger;
+use InterSoccer\ReportsRosters\Data\Repositories\RosterRepository;
+use InterSoccer\ReportsRosters\Services\RosterListingService;
+use InterSoccer\ReportsRosters\Tests\TestCase;
+use Mockery;
+use ReflectionMethod;
+
+class RosterListingServicePerfTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        if (!function_exists('sanitize_text_field')) {
+            eval('function sanitize_text_field($str) { return trim((string) $str); }');
+        }
+        if (!function_exists('sanitize_key')) {
+            eval('function sanitize_key($key) { return strtolower(preg_replace("/[^a-z0-9_-]/", "", (string) $key)); }');
+        }
+        if (!function_exists('intersoccer_normalize_season_for_display')) {
+            eval('function intersoccer_normalize_season_for_display($season) { return (string) $season; }');
+        }
+        if (!function_exists('get_term_by')) {
+            eval('function get_term_by($field, $value, $taxonomy = "", $output = OBJECT, $filter = "raw") { return false; }');
+        }
+    }
+
+    public function test_listing_allowed_order_statuses() {
+        $db = new Database(new Logger());
+        $statuses = $db->get_listing_allowed_order_statuses();
+        $this->assertContains('wc-completed', $statuses);
+        $this->assertContains('wc-processing', $statuses);
+        $this->assertContains('wc-pending', $statuses);
+        $this->assertContains('wc-on-hold', $statuses);
+    }
+
+    public function test_listing_aggregates_sql_joins_posts_and_groups_by_signature() {
+        global $wpdb;
+
+        $logger = Mockery::mock(Logger::class);
+        $logger->shouldReceive('debug')->andReturnNull();
+        $logger->shouldReceive('error')->andReturnNull();
+
+        $wpdb = Mockery::mock('wpdb');
+        $wpdb->prefix = 'wp_';
+        $wpdb->posts = 'wp_posts';
+        $wpdb->last_error = '';
+
+        $captured_sql = '';
+        $captured_values = [];
+        $wpdb->shouldReceive('query')
+            ->with(Mockery::pattern('/group_concat_max_len/'))
+            ->once()
+            ->andReturn(true);
+        $wpdb->shouldReceive('prepare')
+            ->once()
+            ->andReturnUsing(function ($sql, ...$args) use (&$captured_sql, &$captured_values) {
+                $captured_sql = (string) $sql;
+                // wpdb::prepare($sql, $array) passes one array arg.
+                $captured_values = (count($args) === 1 && is_array($args[0])) ? $args[0] : $args;
+                return $sql;
+            });
+        $wpdb->shouldReceive('get_results')
+            ->once()
+            ->andReturn([]);
+
+        $db = new Database($logger);
+        $rows = $db->get_roster_listing_aggregates([
+            'is_placeholder' => 0,
+            'activity_type' => ['Camp'],
+            'venue' => 'Geneva',
+            'event_completed' => 0,
+        ]);
+
+        $this->assertSame([], $rows);
+        $this->assertStringContainsString('INNER JOIN', $captured_sql);
+        $this->assertStringContainsString('wp_posts', $captured_sql);
+        $this->assertStringContainsString('p.post_status IN', $captured_sql);
+        $this->assertStringContainsString('GROUP BY', $captured_sql);
+        $this->assertStringContainsString('r.venue = %s', $captured_sql);
+        $this->assertStringContainsString('r.event_completed = %s', $captured_sql);
+        $this->assertContains('wc-completed', $captured_values);
+        $this->assertContains('wc-processing', $captured_values);
+        $this->assertContains('Geneva', $captured_values);
+    }
+
+    public function test_map_listing_aggregates_expands_csv_ids() {
+        $repository = Mockery::mock(RosterRepository::class);
+        $service = new RosterListingService(null, $repository);
+
+        $method = new ReflectionMethod(RosterListingService::class, 'mapListingAggregatesToRows');
+        $method->setAccessible(true);
+        $rows = $method->invoke($service, [[
+            'group_key' => 'sig-1',
+            'event_signature' => 'sig-1',
+            'player_count' => 2,
+            'product_id' => 10,
+            'product_name' => 'Camp',
+            'venue' => 'Geneva',
+            'city' => 'Geneva',
+            'age_group' => '5-13y',
+            'camp_terms' => 'Week 1',
+            'course_day' => '',
+            'times' => '09:00',
+            'season' => 'Summer 2026',
+            'activity_type' => 'Camp',
+            'start_date' => '2026-07-01',
+            'end_date' => '2026-07-05',
+            'event_completed' => 0,
+            'girls_only' => 0,
+            'order_item_ids_csv' => '101,102',
+            'variation_ids_csv' => '55',
+            'event_signatures_csv' => 'sig-1',
+        ]]);
+
+        $this->assertCount(1, $rows);
+        $this->assertTrue(!empty($rows[0]['_listing_aggregate']));
+        $this->assertSame([101, 102], $rows[0]['order_item_ids']);
+        $this->assertSame([55], $rows[0]['variation_ids']);
+        $this->assertSame(2, $rows[0]['player_count']);
+    }
+
+    public function test_aggregate_camp_groups_accepts_listing_aggregate_rows() {
+        $repository = Mockery::mock(RosterRepository::class);
+        $service = new RosterListingService(null, $repository);
+
+        $method = new ReflectionMethod(RosterListingService::class, 'aggregateCampGroups');
+        $method->setAccessible(true);
+        $result = $method->invoke($service, [[
+            '_listing_aggregate' => true,
+            'event_signature' => 'sig-agg',
+            'order_item_ids' => [201, 202, 203],
+            'variation_ids' => [9],
+            'merged_event_signatures' => ['sig-agg'],
+            'venue' => 'Zurich',
+            'camp_terms' => 'Week 2',
+            'season' => 'Summer 2026',
+            'city' => 'Zurich',
+            'age_group' => '5-13y',
+            'times' => '09:00',
+            'product_name' => 'Camp',
+            'girls_only' => 0,
+            'event_completed' => 0,
+            'start_date' => '2026-07-08',
+            'end_date' => '2026-07-12',
+            'product_id' => 1,
+        ]], false, false);
+
+        $groups = array_values($result['groups']);
+        $this->assertCount(1, $groups);
+        $this->assertSame(3, $groups[0]['total_players']);
+        $this->assertSame([201, 202, 203], $groups[0]['order_item_ids']);
+    }
+
+    public function test_empty_camp_response_shape() {
+        $repository = Mockery::mock(RosterRepository::class);
+        $repository->shouldReceive('getListingAggregates')->andReturn([]);
+        $service = new RosterListingService(null, $repository);
+        $result = $service->getCampListings([], [], false);
+
+        $this->assertSame([], $result['all_groups']);
+        $this->assertSame([], $result['display_groups']);
+        $this->assertSame([], $result['grouped']);
+        $this->assertArrayHasKey('seasons', $result['filters']);
+    }
+}


### PR DESCRIPTION
Collapses legacy Camps/Courses/Girls Only/Tournaments menu pages into a single Rosters view with activity filters, adds listing aggregate queries, and expands PHPUnit coverage for girls-only and listing performance.