### PR TITLE
Add Rosters Girls Only Yes/No filter and retire All Rosters.

### DIFF
--- a/classes/Admin/asset-manager.php
+++ b/classes/Admin/asset-manager.php
@@ -71,8 +71,8 @@ class AssetManager {
         }
 
         // Roster listing pages (tabs + close/reopen actions)
+        // intersoccer-all-rosters redirects to Rosters — no assets needed for that slug.
         $roster_pages = [
-            'intersoccer-reports-rosters_page_intersoccer-all-rosters',
             'intersoccer-reports-rosters_page_intersoccer-rosters',
             'intersoccer-reports-rosters_page_intersoccer-camps',
             'intersoccer-reports-rosters_page_intersoccer-courses',

--- a/classes/Admin/menu-manager.php
+++ b/classes/Admin/menu-manager.php
@@ -149,15 +149,6 @@ class MenuManager {
 
         add_submenu_page(
             'intersoccer-reports-rosters',
-            __('All Rosters', 'intersoccer-reports-rosters'),
-            __('All Rosters', 'intersoccer-reports-rosters'),
-            'read',
-            'intersoccer-all-rosters',
-            [$this, 'render_all_rosters']
-        );
-
-        add_submenu_page(
-            'intersoccer-reports-rosters',
             __('Rosters', 'intersoccer-reports-rosters'),
             __('Rosters', 'intersoccer-reports-rosters'),
             'read',
@@ -166,6 +157,8 @@ class MenuManager {
         );
 
         // Hidden legacy list pages → unified Rosters with activity_type.
+        // All Rosters retired: consolidated into Rosters (keep slug for redirects/bookmarks).
+        add_submenu_page(null, '', '', 'read', 'intersoccer-all-rosters', [$this, 'render_legacy_all_rosters_redirect']);
         add_submenu_page(null, '', '', 'read', 'intersoccer-camps', [$this, 'render_legacy_camps_redirect']);
         add_submenu_page(null, '', '', 'read', 'intersoccer-courses', [$this, 'render_legacy_courses_redirect']);
         add_submenu_page(null, '', '', 'read', 'intersoccer-girls-only', [$this, 'render_legacy_girls_only_redirect']);
@@ -346,12 +339,12 @@ class MenuManager {
     }
 
     public function render_all_rosters(): void {
-        $this->require_include('rosters.php');
-        if (function_exists('intersoccer_render_all_rosters_page')) {
-            intersoccer_render_all_rosters_page();
-            return;
-        }
-        wp_die(__('All rosters page is not available.', 'intersoccer-reports-rosters'));
+        $this->render_legacy_all_rosters_redirect();
+    }
+
+    public function render_legacy_all_rosters_redirect(): void {
+        wp_safe_redirect(admin_url('admin.php?page=intersoccer-rosters'));
+        exit;
     }
 
     public function render_rosters(): void {
@@ -372,7 +365,15 @@ class MenuManager {
     }
 
     public function render_legacy_girls_only_redirect(): void {
-        $this->redirect_legacy_list_page('girls_only');
+        $this->require_include('rosters.php');
+        if (function_exists('intersoccer_rosters_unified_url')) {
+            $get = $_GET;
+            $get['girls_only_mode'] = 'yes';
+            wp_safe_redirect(intersoccer_rosters_unified_url('camps', $get));
+            exit;
+        }
+        wp_safe_redirect(admin_url('admin.php?page=intersoccer-rosters&activity_type=camps&girls_only_mode=yes'));
+        exit;
     }
 
     public function render_legacy_tournaments_redirect(): void {
@@ -380,7 +381,7 @@ class MenuManager {
     }
 
     /**
-     * @param string $activity_type camps|courses|girls_only|tournaments
+     * @param string $activity_type camps|courses|tournaments
      */
     private function redirect_legacy_list_page(string $activity_type): void {
         $this->require_include('rosters.php');

--- a/classes/Core/Plugin.php
+++ b/classes/Core/Plugin.php
@@ -338,7 +338,8 @@ final class Plugin {
             return;
         }
         // Load rosters.php early (before admin_head) when on a roster page so card CSS is registered
-        $roster_pages = ['intersoccer-rosters', 'intersoccer-camps', 'intersoccer-courses', 'intersoccer-girls-only', 'intersoccer-tournaments', 'intersoccer-other-events', 'intersoccer-all-rosters', 'intersoccer-birthdays'];
+        // intersoccer-all-rosters redirects to Rosters (no early includes needed).
+        $roster_pages = ['intersoccer-rosters', 'intersoccer-camps', 'intersoccer-courses', 'intersoccer-girls-only', 'intersoccer-tournaments', 'intersoccer-other-events', 'intersoccer-birthdays'];
         $page = isset($_GET['page']) ? sanitize_text_field(wp_unslash($_GET['page'])) : '';
         if (in_array($page, $roster_pages, true)) {
             $includes_to_load = [$this->plugin_path . 'includes/rosters.php'];

--- a/classes/services/roster-builder.php
+++ b/classes/services/roster-builder.php
@@ -831,6 +831,10 @@ class RosterBuilder {
             if ($canonical_key === 'assigned_player_id' || $raw_key === 'assigned_player_id') {
                 $order_data['player_id'] = $value;
             }
+            // Language-neutral girls-only flag (not in display field map).
+            if ($raw_key === '_intersoccer_canonical_girls_only' || $canonical_key === '_intersoccer_canonical_girls_only') {
+                $order_data['_intersoccer_canonical_girls_only'] = $value;
+            }
         }
 
         if (function_exists('intersoccer_apply_order_item_attribute_meta_to_data')) {

--- a/classes/services/roster-listing-service.php
+++ b/classes/services/roster-listing-service.php
@@ -455,24 +455,35 @@ class RosterListingService {
      */
     private function normaliseGirlsOnlyMode($mode): string {
         $mode = sanitize_key((string) $mode);
-        if (in_array($mode, ['all', 'girls_only'], true)) {
-            return $mode;
+        if (in_array($mode, ['yes', 'girls_only'], true)) {
+            return 'girls_only';
+        }
+        if (in_array($mode, ['no', 'mixed'], true)) {
+            return 'mixed';
+        }
+        if ($mode === 'all' || $mode === '') {
+            return 'all';
         }
 
-        return 'mixed';
+        return 'all';
     }
 
     /**
      * Repository girls_only criterion for camp/course listings.
      *
+     * Yes/No listing uses PHP post-filter (product_name / activity_type / flag) so
+     * rows with Girls Only=Yes meta but stale girls_only=0 are not dropped by SQL.
+     * Dedicated getGirlsOnlyListings still passes $legacyGirlsOnlyFlag=true → SQL =1.
+     *
      * @param array<string,mixed> $filters
      * @return array<string,int>
      */
     private function resolveGirlsOnlyRepositoryCriteria(array $filters, bool $legacyGirlsOnlyFlag): array {
-        // Post-query filtering handles girls-only detection using product_name,
-        // activity_type, and pa_girls-only — not just the DB flag column.
-        // This ensures older orders (girls_only=0 but product name contains
-        // "Girls Only") are correctly routed to/from the Girls Only page.
+        if ($legacyGirlsOnlyFlag) {
+            return ['girls_only' => 1];
+        }
+
+        // Intentionally empty: SQL on girls_only hides unreconciled Yes-meta rows (flag still 0).
         return [];
     }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,3 +12,10 @@ Live agent and developer guidance for this plugin lives in the InterSoccer works
 - Ops refs: `cleanup-playbook.md`, `date-parsing.md` under the skill folder
 
 Historical writeups and one-off fix notes: [archive/](archive/).
+
+## Admin Rosters UX (unified page)
+
+- Use **Reports & Rosters → Rosters** with **Activity Type** (Camps | Courses | Tournaments).
+- **Girls Only** is a separate filter (All | Yes | No) on Camps/Courses, backed by the `pa_girls-only` product attribute → `rosters.girls_only` after Order Meta Repair → Reconcile.
+- Legacy `activity_type=girls_only` and `intersoccer-girls-only` redirect to Camps with Girls Only = Yes.
+- Legacy **All Rosters** URL (`intersoccer-all-rosters`) redirects to Rosters. Reconcile and per-activity exports remain on Rosters. Advanced still has Export All Rosters (CSV).

--- a/includes/roster-list-filter-persistence.php
+++ b/includes/roster-list-filter-persistence.php
@@ -128,7 +128,6 @@ function intersoccer_rosters_flash_notice_allowed_pages(): array {
         'intersoccer-tournaments',
         'intersoccer-other-events',
         'intersoccer-birthdays',
-        'intersoccer-all-rosters',
         'intersoccer-roster-details',
         'intersoccer-signature-drift',
         'intersoccer-reports-rosters',
@@ -178,7 +177,6 @@ function intersoccer_rosters_reconcile_page_slugs(): array {
         'intersoccer-girls-only',
         'intersoccer-tournaments',
         'intersoccer-other-events',
-        'intersoccer-all-rosters',
     ];
 }
 

--- a/includes/rosters.php
+++ b/includes/rosters.php
@@ -1068,17 +1068,28 @@ function intersoccer_rosters_admin_status_filter_label($status_filter) {
 }
 
 /**
- * Girls-only event filter for Camps/Courses listings (mixed = default, excludes girls-only rows).
+ * Girls Only attribute filter for Camps/Courses listings.
+ *
+ * Backed by rosters.girls_only (from pa_girls-only Yes/No). Modes:
+ * - all: no girls_only restriction (default)
+ * - girls_only / yes: girls_only = 1
+ * - mixed / no: girls_only = 0 (non–girls-only rows)
  *
  * @return string mixed|all|girls_only
  */
 function intersoccer_rosters_admin_girls_only_mode_from_request() {
     $raw = isset($_GET['girls_only_mode']) ? sanitize_key(wp_unslash((string) $_GET['girls_only_mode'])) : '';
-    if (in_array($raw, ['all', 'girls_only'], true)) {
-        return $raw;
+    if (in_array($raw, ['yes', 'girls_only'], true)) {
+        return 'girls_only';
+    }
+    if (in_array($raw, ['no', 'mixed'], true)) {
+        return 'mixed';
+    }
+    if ($raw === 'all') {
+        return 'all';
     }
 
-    return 'mixed';
+    return 'all';
 }
 
 /**
@@ -1086,31 +1097,44 @@ function intersoccer_rosters_admin_girls_only_mode_from_request() {
  */
 function intersoccer_rosters_admin_girls_only_mode_filter_label($girls_only_mode) {
     switch ($girls_only_mode) {
-        case 'all':
-            return __('All events', 'intersoccer-reports-rosters');
         case 'girls_only':
-            return __('Girls Only', 'intersoccer-reports-rosters');
+            return __('Yes', 'intersoccer-reports-rosters');
+        case 'mixed':
+            return __('No', 'intersoccer-reports-rosters');
         default:
-            return __('Mixed events', 'intersoccer-reports-rosters');
+            return __('All', 'intersoccer-reports-rosters');
     }
 }
 
 /**
  * Allowed Activity Type values for the unified Rosters admin page.
+ * Girls Only is a separate Yes/No attribute filter, not an activity type.
  *
  * @return string[]
  */
 function intersoccer_rosters_admin_activity_types() {
-    return ['camps', 'courses', 'girls_only', 'tournaments'];
+    return ['camps', 'courses', 'tournaments'];
 }
 
 /**
  * Activity Type filter for the unified Rosters page (default camps).
  *
- * @return string camps|courses|girls_only|tournaments
+ * Obsolete activity_type=girls_only is remapped to camps + girls_only_mode=yes.
+ *
+ * @return string camps|courses|tournaments
  */
 function intersoccer_rosters_admin_activity_type_from_request() {
     $raw = isset($_GET['activity_type']) ? sanitize_key(wp_unslash((string) $_GET['activity_type'])) : '';
+    if ($raw === 'girls_only') {
+        if (!isset($_GET['girls_only_mode']) || (string) $_GET['girls_only_mode'] === '') {
+            $_GET['girls_only_mode'] = 'yes';
+            $_REQUEST['girls_only_mode'] = 'yes';
+        }
+        $_GET['activity_type'] = 'camps';
+        $_REQUEST['activity_type'] = 'camps';
+
+        return 'camps';
+    }
     if (in_array($raw, intersoccer_rosters_admin_activity_types(), true)) {
         return $raw;
     }
@@ -1119,14 +1143,12 @@ function intersoccer_rosters_admin_activity_type_from_request() {
 }
 
 /**
- * @param string $activity_type camps|courses|girls_only|tournaments
+ * @param string $activity_type camps|courses|tournaments
  */
 function intersoccer_rosters_admin_activity_type_filter_label($activity_type) {
     switch ($activity_type) {
         case 'courses':
             return __('Courses', 'intersoccer-reports-rosters');
-        case 'girls_only':
-            return __('Girls Only', 'intersoccer-reports-rosters');
         case 'tournaments':
             return __('Tournaments', 'intersoccer-reports-rosters');
         default:
@@ -1158,6 +1180,7 @@ function intersoccer_rosters_list_page_slug($legacy_slug = 'intersoccer-camps') 
 
 /**
  * Map legacy list page slugs → activity_type.
+ * intersoccer-girls-only redirects to camps + Girls Only = Yes (handled in redirect helper).
  *
  * @return array<string,string>
  */
@@ -1165,7 +1188,6 @@ function intersoccer_rosters_legacy_page_activity_type_map() {
     return [
         'intersoccer-camps' => 'camps',
         'intersoccer-courses' => 'courses',
-        'intersoccer-girls-only' => 'girls_only',
         'intersoccer-tournaments' => 'tournaments',
     ];
 }
@@ -1173,11 +1195,17 @@ function intersoccer_rosters_legacy_page_activity_type_map() {
 /**
  * Build unified Rosters URL, optionally preserving safe GET filters.
  *
- * @param string               $activity_type camps|courses|girls_only|tournaments
+ * @param string               $activity_type camps|courses|tournaments
  * @param array<string,mixed>  $source_get    Usually $_GET from a legacy bookmark.
  */
 function intersoccer_rosters_unified_url($activity_type, array $source_get = []) {
     $activity_type = sanitize_key((string) $activity_type);
+    if ($activity_type === 'girls_only') {
+        $activity_type = 'camps';
+        if (!isset($source_get['girls_only_mode']) || (string) $source_get['girls_only_mode'] === '') {
+            $source_get['girls_only_mode'] = 'yes';
+        }
+    }
     if (!in_array($activity_type, intersoccer_rosters_admin_activity_types(), true)) {
         $activity_type = 'camps';
     }
@@ -1197,6 +1225,7 @@ function intersoccer_rosters_unified_url($activity_type, array $source_get = [])
         'status',
         'times',
         'type',
+        'girls_only_mode',
         'consolidated',
         'action',
         '_wpnonce',
@@ -1221,8 +1250,18 @@ function intersoccer_rosters_unified_url($activity_type, array $source_get = [])
  * @return bool True when a redirect was issued (does not return).
  */
 function intersoccer_rosters_maybe_redirect_legacy_list_page($page) {
-    $map = intersoccer_rosters_legacy_page_activity_type_map();
     $page = sanitize_key((string) $page);
+    if ($page === 'intersoccer-girls-only') {
+        if (headers_sent()) {
+            return false;
+        }
+        $get = $_GET;
+        $get['girls_only_mode'] = 'yes';
+        wp_safe_redirect(intersoccer_rosters_unified_url('camps', $get));
+        exit;
+    }
+
+    $map = intersoccer_rosters_legacy_page_activity_type_map();
     if (!isset($map[$page])) {
         return false;
     }
@@ -1238,7 +1277,10 @@ function intersoccer_rosters_maybe_redirect_legacy_list_page($page) {
 /**
  * Print the Activity Type filter for the unified Rosters page.
  *
- * @param string $current camps|courses|girls_only|tournaments
+ * Activity Type is Camps | Courses | Tournaments. Girls Only is a separate Yes/No filter
+ * (pa_girls-only attribute → rosters.girls_only).
+ *
+ * @param string $current camps|courses|tournaments
  */
 function intersoccer_rosters_admin_print_activity_type_filter($current) {
     $current = sanitize_key((string) $current);
@@ -1251,7 +1293,6 @@ function intersoccer_rosters_admin_print_activity_type_filter($current) {
         <select name="activity_type" onchange="this.form.submit()">
             <option value="camps" <?php selected($current, 'camps'); ?>><?php esc_html_e('Camps', 'intersoccer-reports-rosters'); ?></option>
             <option value="courses" <?php selected($current, 'courses'); ?>><?php esc_html_e('Courses', 'intersoccer-reports-rosters'); ?></option>
-            <option value="girls_only" <?php selected($current, 'girls_only'); ?>><?php esc_html_e('Girls Only', 'intersoccer-reports-rosters'); ?></option>
             <option value="tournaments" <?php selected($current, 'tournaments'); ?>><?php esc_html_e('Tournaments', 'intersoccer-reports-rosters'); ?></option>
         </select>
     </div>
@@ -1259,7 +1300,31 @@ function intersoccer_rosters_admin_print_activity_type_filter($current) {
 }
 
 /**
- * Unified Rosters admin page — dispatches by Activity Type.
+ * Print Girls Only Yes/No/All filter (product attribute → rosters.girls_only).
+ *
+ * @param string $current mixed|all|girls_only
+ */
+function intersoccer_rosters_admin_print_girls_only_filter($current) {
+    $current = sanitize_key((string) $current);
+    if (!in_array($current, ['all', 'mixed', 'girls_only'], true)) {
+        $current = 'all';
+    }
+    ?>
+    <div class="filter-group">
+        <label><?php esc_html_e('Girls Only', 'intersoccer-reports-rosters'); ?></label>
+        <select name="girls_only_mode" onchange="this.form.submit()">
+            <option value="all" <?php selected($current, 'all'); ?>><?php esc_html_e('All', 'intersoccer-reports-rosters'); ?></option>
+            <option value="yes" <?php selected($current, 'girls_only'); ?>><?php esc_html_e('Yes', 'intersoccer-reports-rosters'); ?></option>
+            <option value="no" <?php selected($current, 'mixed'); ?>><?php esc_html_e('No', 'intersoccer-reports-rosters'); ?></option>
+        </select>
+    </div>
+    <?php
+}
+
+/**
+ * Unified Rosters admin page — dispatches by Activity Type (Camps / Courses / Tournaments).
+ *
+ * Girls Only is filtered via girls_only_mode (All / Yes / No), not a peer Activity Type.
  */
 function intersoccer_render_rosters_page() {
     if (!current_user_can('manage_options') && !current_user_can('coach')) {
@@ -1270,18 +1335,9 @@ function intersoccer_render_rosters_page() {
     $_GET['activity_type'] = $activity_type;
     $_REQUEST['activity_type'] = $activity_type;
 
-    // Camps/Courses on the unified page are mixed-only (Girls Only is a peer Activity Type).
-    if ($activity_type === 'camps' || $activity_type === 'courses') {
-        $_GET['girls_only_mode'] = 'mixed';
-        $_REQUEST['girls_only_mode'] = 'mixed';
-    }
-
     switch ($activity_type) {
         case 'courses':
             intersoccer_render_courses_page();
-            return;
-        case 'girls_only':
-            intersoccer_render_girls_only_page();
             return;
         case 'tournaments':
             intersoccer_render_tournaments_page();
@@ -1337,12 +1393,11 @@ function intersoccer_render_camps_page() {
     $activity_type = $unified ? intersoccer_rosters_admin_activity_type_from_request() : 'camps';
 
     if (function_exists('intersoccer_rosters_bootstrap_saved_list_filters')) {
-        $filter_keys = ['season', 'venue', 'camp_terms', 'age_group', 'city', 'status'];
+        $filter_keys = ['season', 'venue', 'camp_terms', 'age_group', 'city', 'status', 'girls_only_mode'];
         if ($unified) {
             $filter_keys[] = 'activity_type';
             intersoccer_rosters_bootstrap_saved_list_filters('rosters_camps', $filter_keys, true);
         } else {
-            $filter_keys[] = 'girls_only_mode';
             intersoccer_rosters_bootstrap_saved_list_filters('camps', $filter_keys, true);
         }
     }
@@ -1371,8 +1426,7 @@ function intersoccer_render_camps_page() {
     $selected_age_group = isset($_GET['age_group']) ? sanitize_text_field($_GET['age_group']) : '';
     $selected_city = isset($_GET['city']) ? sanitize_text_field($_GET['city']) : '';
     $status_filter = isset($_GET['status']) ? sanitize_text_field($_GET['status']) : '';
-    // Unified Rosters: Camps = mixed only; legacy Event type filter retained only off unified page.
-    $girls_only_mode = $unified ? 'mixed' : intersoccer_rosters_admin_girls_only_mode_from_request();
+    $girls_only_mode = intersoccer_rosters_admin_girls_only_mode_from_request();
     $show_closed = ($status_filter === 'closed' || $status_filter === 'all') ? $status_filter : false;
     $consolidated_view = intersoccer_roster_admin_consolidated_view_from_request();
 
@@ -1451,9 +1505,11 @@ function intersoccer_render_camps_page() {
             __('Activity Type: %s', 'intersoccer-reports-rosters'),
             intersoccer_rosters_admin_activity_type_filter_label($activity_type)
         );
-    } elseif ($girls_only_mode !== 'mixed') {
+    }
+    if ($girls_only_mode !== 'all') {
         $camp_active_filter_labels[] = sprintf(
-            __('Event type: %s', 'intersoccer-reports-rosters'),
+            /* translators: %s: All, Yes, or No */
+            __('Girls Only: %s', 'intersoccer-reports-rosters'),
             intersoccer_rosters_admin_girls_only_mode_filter_label($girls_only_mode)
         );
     }
@@ -1597,16 +1653,7 @@ function intersoccer_render_camps_page() {
                 <option value="all" <?php selected($status_filter, 'all'); ?>>All</option>
             </select>
         </div>
-        <?php if (!$unified) : ?>
-        <div class="filter-group">
-            <label><?php esc_html_e('Event type', 'intersoccer-reports-rosters'); ?></label>
-            <select name="girls_only_mode" onchange="this.form.submit()">
-                <option value="mixed" <?php selected($girls_only_mode, 'mixed'); ?>><?php esc_html_e('Mixed events', 'intersoccer-reports-rosters'); ?></option>
-                <option value="all" <?php selected($girls_only_mode, 'all'); ?>><?php esc_html_e('All events', 'intersoccer-reports-rosters'); ?></option>
-                <option value="girls_only" <?php selected($girls_only_mode, 'girls_only'); ?>><?php esc_html_e('Girls Only', 'intersoccer-reports-rosters'); ?></option>
-            </select>
-        </div>
-        <?php endif; ?>
+        <?php intersoccer_rosters_admin_print_girls_only_filter($girls_only_mode); ?>
         <div class="filter-group">
             <label style="display:flex;align-items:center;gap:6px;">
                 <input type="hidden" name="consolidated" value="0" />
@@ -1614,7 +1661,7 @@ function intersoccer_render_camps_page() {
                 <?php _e('Consolidated (all languages)', 'intersoccer-reports-rosters'); ?>
             </label>
         </div>
-        <?php if ($selected_season || $selected_venue || $selected_camp_terms || $selected_age_group || $selected_city || $status_filter || (!$unified && $girls_only_mode !== 'mixed')): ?>
+        <?php if ($selected_season || $selected_venue || $selected_camp_terms || $selected_age_group || $selected_city || $status_filter || $girls_only_mode !== 'all'): ?>
                 <div class="filter-group">
                     <a href="<?php echo esc_url($clear_filters_url); ?>" class="button button-secondary">
                         ↻ <?php _e('Clear Filters', 'intersoccer-reports-rosters'); ?>
@@ -1765,12 +1812,11 @@ function intersoccer_render_courses_page() {
     $activity_type = $unified ? intersoccer_rosters_admin_activity_type_from_request() : 'courses';
 
     if (function_exists('intersoccer_rosters_bootstrap_saved_list_filters')) {
-        $filter_keys = ['season', 'venue', 'course_day', 'age_group', 'city', 'status'];
+        $filter_keys = ['season', 'venue', 'course_day', 'age_group', 'city', 'status', 'girls_only_mode'];
         if ($unified) {
             $filter_keys[] = 'activity_type';
             intersoccer_rosters_bootstrap_saved_list_filters('rosters_courses', $filter_keys, true);
         } else {
-            $filter_keys[] = 'girls_only_mode';
             intersoccer_rosters_bootstrap_saved_list_filters('courses', $filter_keys, true);
         }
     }
@@ -1794,7 +1840,7 @@ function intersoccer_render_courses_page() {
     }
 
     $status_filter = isset($_GET['status']) ? sanitize_text_field($_GET['status']) : '';
-    $girls_only_mode = $unified ? 'mixed' : intersoccer_rosters_admin_girls_only_mode_from_request();
+    $girls_only_mode = intersoccer_rosters_admin_girls_only_mode_from_request();
 
     $selected_season = isset($_GET['season']) ? sanitize_text_field($_GET['season']) : '';
     $selected_venue = isset($_GET['venue']) ? sanitize_text_field($_GET['venue']) : '';
@@ -1879,9 +1925,11 @@ function intersoccer_render_courses_page() {
             __('Activity Type: %s', 'intersoccer-reports-rosters'),
             intersoccer_rosters_admin_activity_type_filter_label($activity_type)
         );
-    } elseif ($girls_only_mode !== 'mixed') {
+    }
+    if ($girls_only_mode !== 'all') {
         $course_active_filter_labels[] = sprintf(
-            __('Event type: %s', 'intersoccer-reports-rosters'),
+            /* translators: %s: All, Yes, or No */
+            __('Girls Only: %s', 'intersoccer-reports-rosters'),
             intersoccer_rosters_admin_girls_only_mode_filter_label($girls_only_mode)
         );
     }
@@ -2025,16 +2073,7 @@ function intersoccer_render_courses_page() {
                         <option value="all" <?php selected($status_filter, 'all'); ?>>All</option>
                     </select>
                 </div>
-                <?php if (!$unified) : ?>
-                <div class="filter-group">
-                    <label><?php esc_html_e('Event type', 'intersoccer-reports-rosters'); ?></label>
-                    <select name="girls_only_mode" onchange="this.form.submit()">
-                        <option value="mixed" <?php selected($girls_only_mode, 'mixed'); ?>><?php esc_html_e('Mixed events', 'intersoccer-reports-rosters'); ?></option>
-                        <option value="all" <?php selected($girls_only_mode, 'all'); ?>><?php esc_html_e('All events', 'intersoccer-reports-rosters'); ?></option>
-                        <option value="girls_only" <?php selected($girls_only_mode, 'girls_only'); ?>><?php esc_html_e('Girls Only', 'intersoccer-reports-rosters'); ?></option>
-                    </select>
-                </div>
-                <?php endif; ?>
+                <?php intersoccer_rosters_admin_print_girls_only_filter($girls_only_mode); ?>
                 <div class="filter-group">
                     <label style="display:flex;align-items:center;gap:6px;">
                         <input type="hidden" name="consolidated" value="0" />
@@ -2042,7 +2081,7 @@ function intersoccer_render_courses_page() {
                         <?php _e('Consolidated (all languages)', 'intersoccer-reports-rosters'); ?>
                     </label>
                 </div>
-                <?php if ($selected_season || $selected_venue || $selected_course_day || $selected_age_group || $selected_city || $status_filter || (!$unified && $girls_only_mode !== 'mixed')): ?>
+                <?php if ($selected_season || $selected_venue || $selected_course_day || $selected_age_group || $selected_city || $status_filter || $girls_only_mode !== 'all'): ?>
                 <div class="filter-group">
                     <a href="<?php echo esc_url($clear_filters_url); ?>" class="button button-secondary">
                         ↻ <?php _e('Clear Filters', 'intersoccer-reports-rosters'); ?>

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -5319,11 +5319,42 @@ if (!function_exists('intersoccer_resolve_roster_girls_only_flag')) {
     /**
      * Resolve the girls_only roster flag (0 or 1) from order-item / roster facets.
      *
+     * Prefers language-neutral `_intersoccer_canonical_girls_only`, then display/
+     * attribute Yes|No values (including mapped `girls_only` / `Girls Only`), then
+     * activity-type / product-name / WC attribute fallbacks.
+     *
      * @param array<string,mixed> $context
      * @return int
      */
     function intersoccer_resolve_roster_girls_only_flag(array $context) {
+        $normalize_val = static function ($val) {
+            if (is_array($val)) {
+                $val = $val[0] ?? reset($val);
+            }
+            return $val;
+        };
+
+        // Canonical 0/1 (or yes/no) written at checkout/repair — authoritative when present.
+        if (array_key_exists('_intersoccer_canonical_girls_only', $context)
+            && $context['_intersoccer_canonical_girls_only'] !== ''
+            && $context['_intersoccer_canonical_girls_only'] !== null) {
+            $canonical = $normalize_val($context['_intersoccer_canonical_girls_only']);
+            if (intersoccer_pa_girls_only_slug_is_yes($canonical) || (string) $canonical === '1' || $canonical === 1 || $canonical === true) {
+                return 1;
+            }
+            if (in_array(strtolower(trim((string) $canonical)), ['0', 'no', 'mixed', 'false'], true)
+                || $canonical === 0
+                || $canonical === false) {
+                return 0;
+            }
+        }
+
         $girls_meta_keys = [
+            'Girls Only',
+            'girls_only',
+            'Filles uniquement',
+            'Nur Mädchen',
+            'Nur Madchen',
             'pa_girls-only',
             'attribute_pa_girls-only',
             'girls-only',
@@ -5334,9 +5365,15 @@ if (!function_exists('intersoccer_resolve_roster_girls_only_flag')) {
             if (!array_key_exists($key, $context) || $context[$key] === '' || $context[$key] === null) {
                 continue;
             }
-            $val = $context[$key];
-            if (is_array($val)) {
-                $val = $val[0] ?? reset($val);
+            $val = $normalize_val($context[$key]);
+
+            // Integer 0 on a denormalized row is not decisive — activity/product text may still
+            // indicate girls-only (backfill / looks_girls_only). Explicit "No"/"mixed" is decisive.
+            if ($val === 0 || $val === false) {
+                continue;
+            }
+            if ($val === 1 || $val === true || (string) $val === '1') {
+                return 1;
             }
             if (intersoccer_pa_girls_only_slug_is_yes($val)) {
                 return 1;

--- a/tests/Legacy/RostersAdminActivityTypeTest.php
+++ b/tests/Legacy/RostersAdminActivityTypeTest.php
@@ -61,14 +61,27 @@ class RostersAdminActivityTypeTest extends TestCase {
             $this->markTestSkipped('activity type helper not loaded');
         }
 
-        foreach (['camps', 'courses', 'girls_only', 'tournaments'] as $type) {
+        foreach (['camps', 'courses', 'tournaments'] as $type) {
             $_GET['activity_type'] = $type;
+            unset($_GET['girls_only_mode'], $_REQUEST['girls_only_mode']);
             $this->assertSame($type, intersoccer_rosters_admin_activity_type_from_request());
         }
 
         $_GET['activity_type'] = 'birthday';
         $this->assertSame('camps', intersoccer_rosters_admin_activity_type_from_request());
         unset($_GET['activity_type']);
+    }
+
+    public function test_obsolete_girls_only_activity_type_remaps_to_camps_with_yes_filter(): void {
+        if (!function_exists('intersoccer_rosters_admin_activity_type_from_request')) {
+            $this->markTestSkipped('activity type helper not loaded');
+        }
+
+        unset($_GET['girls_only_mode'], $_REQUEST['girls_only_mode']);
+        $_GET['activity_type'] = 'girls_only';
+        $this->assertSame('camps', intersoccer_rosters_admin_activity_type_from_request());
+        $this->assertSame('yes', $_GET['girls_only_mode']);
+        unset($_GET['activity_type'], $_GET['girls_only_mode'], $_REQUEST['girls_only_mode']);
     }
 
     public function test_legacy_page_activity_type_map(): void {
@@ -79,7 +92,7 @@ class RostersAdminActivityTypeTest extends TestCase {
         $map = intersoccer_rosters_legacy_page_activity_type_map();
         $this->assertSame('camps', $map['intersoccer-camps']);
         $this->assertSame('courses', $map['intersoccer-courses']);
-        $this->assertSame('girls_only', $map['intersoccer-girls-only']);
+        $this->assertArrayNotHasKey('intersoccer-girls-only', $map);
         $this->assertSame('tournaments', $map['intersoccer-tournaments']);
     }
 
@@ -92,6 +105,7 @@ class RostersAdminActivityTypeTest extends TestCase {
             'page' => 'intersoccer-courses',
             'season' => 'autumn-2026',
             'venue' => 'geneva',
+            'girls_only_mode' => 'yes',
             'evil' => 'nope',
         ]);
 
@@ -99,7 +113,18 @@ class RostersAdminActivityTypeTest extends TestCase {
         $this->assertStringContainsString('activity_type=courses', $url);
         $this->assertStringContainsString('season=autumn-2026', $url);
         $this->assertStringContainsString('venue=geneva', $url);
+        $this->assertStringContainsString('girls_only_mode=yes', $url);
         $this->assertStringNotContainsString('evil=', $url);
+    }
+
+    public function test_unified_url_girls_only_activity_becomes_camps_yes(): void {
+        if (!function_exists('intersoccer_rosters_unified_url')) {
+            $this->markTestSkipped('unified url helper not loaded');
+        }
+
+        $url = intersoccer_rosters_unified_url('girls_only', []);
+        $this->assertStringContainsString('activity_type=camps', $url);
+        $this->assertStringContainsString('girls_only_mode=yes', $url);
     }
 
     public function test_activity_type_filter_labels(): void {
@@ -108,6 +133,37 @@ class RostersAdminActivityTypeTest extends TestCase {
         }
 
         $this->assertNotSame('', intersoccer_rosters_admin_activity_type_filter_label('camps'));
-        $this->assertNotSame('', intersoccer_rosters_admin_activity_type_filter_label('girls_only'));
+        $this->assertSame('Camps', intersoccer_rosters_admin_activity_type_filter_label('girls_only'));
+    }
+
+    public function test_girls_only_mode_parser_accepts_yes_no_all(): void {
+        if (!function_exists('intersoccer_rosters_admin_girls_only_mode_from_request')) {
+            $this->markTestSkipped('girls only mode helper not loaded');
+        }
+
+        unset($_GET['girls_only_mode']);
+        $this->assertSame('all', intersoccer_rosters_admin_girls_only_mode_from_request());
+
+        $_GET['girls_only_mode'] = 'yes';
+        $this->assertSame('girls_only', intersoccer_rosters_admin_girls_only_mode_from_request());
+        $_GET['girls_only_mode'] = 'no';
+        $this->assertSame('mixed', intersoccer_rosters_admin_girls_only_mode_from_request());
+        $_GET['girls_only_mode'] = 'all';
+        $this->assertSame('all', intersoccer_rosters_admin_girls_only_mode_from_request());
+        unset($_GET['girls_only_mode']);
+    }
+
+    public function test_reconcile_page_slugs_omit_retired_all_rosters(): void {
+        $persist = __DIR__ . '/../../includes/roster-list-filter-persistence.php';
+        if (file_exists($persist)) {
+            require_once $persist;
+        }
+        if (!function_exists('intersoccer_rosters_reconcile_page_slugs')) {
+            $this->markTestSkipped('reconcile page slugs helper not loaded');
+        }
+
+        $slugs = intersoccer_rosters_reconcile_page_slugs();
+        $this->assertContains('intersoccer-rosters', $slugs);
+        $this->assertNotContains('intersoccer-all-rosters', $slugs);
     }
 }

--- a/tests/Legacy/UtilsTest.php
+++ b/tests/Legacy/UtilsTest.php
@@ -164,6 +164,29 @@ class UtilsTest extends TestCase {
         $this->assertSame(0, intersoccer_resolve_roster_girls_only_flag([
             'pa_girls-only' => 'mixed',
         ]));
+        $this->assertSame(1, intersoccer_resolve_roster_girls_only_flag([
+            'Girls Only' => 'Yes',
+            'activity_type' => 'Camp',
+        ]));
+        $this->assertSame(0, intersoccer_resolve_roster_girls_only_flag([
+            'Girls Only' => 'No',
+            'activity_type' => 'Camp',
+        ]));
+        $this->assertSame(1, intersoccer_resolve_roster_girls_only_flag([
+            'girls_only' => 'yes',
+            'activity_type' => 'Camp',
+        ]));
+        $this->assertSame(1, intersoccer_resolve_roster_girls_only_flag([
+            '_intersoccer_canonical_girls_only' => '1',
+            'activity_type' => 'Camp',
+        ]));
+        $this->assertSame(0, intersoccer_resolve_roster_girls_only_flag([
+            '_intersoccer_canonical_girls_only' => '0',
+            'activity_type' => 'Camp, Girls Only',
+        ]));
+        $this->assertSame(1, intersoccer_resolve_roster_girls_only_flag([
+            'pa_girls-only' => 'yes',
+        ]));
     }
 
     public function test_roster_row_looks_girls_only_wraps_resolver() {

--- a/tests/Services/RosterBuilderTest.php
+++ b/tests/Services/RosterBuilderTest.php
@@ -34,6 +34,13 @@ class RosterBuilderTest extends TestCase {
     
     protected function setUp(): void {
         parent::setUp();
+
+        if (!function_exists('intersoccer_resolve_roster_girls_only_flag')) {
+            $utils = dirname(__DIR__, 2) . '/includes/utils.php';
+            if (file_exists($utils)) {
+                require_once $utils;
+            }
+        }
         
         $this->logger = Mockery::mock(Logger::class);
         $this->logger->shouldReceive('info')->andReturn(null);
@@ -167,6 +174,87 @@ class RosterBuilderTest extends TestCase {
 
         $this->assertSame('Camp', $result['activity_type']);
         $this->assertSame(1, $result['girls_only']);
+    }
+
+    public function test_extract_order_item_data_sets_girls_only_from_yes_display_meta() {
+        $order = Mockery::mock('WC_Order');
+        $order->shouldReceive('get_id')->andReturn(43);
+        $order->shouldReceive('get_customer_id')->andReturn(8);
+        $order->shouldReceive('get_status')->andReturn('processing');
+
+        $item = Mockery::mock('WC_Order_Item_Product');
+        $item->shouldReceive('get_product')->andReturn(null);
+        $item->shouldReceive('get_variation_id')->andReturn(37639);
+        $item->shouldReceive('get_product_id')->andReturn(37635);
+        $item->shouldReceive('get_meta')->andReturn('');
+        $item->shouldReceive('get_meta_data')->andReturn([
+            $this->createOrderItemMeta('Activity Type', 'Camp'),
+            $this->createOrderItemMeta('Girls Only', 'Yes'),
+            $this->createOrderItemMeta('pa_program-season', 'summer-camps-2026'),
+            $this->createOrderItemMeta('pa_intersoccer-venues', 'geneva-venue'),
+        ]);
+
+        $reflection = new \ReflectionClass($this->rosterBuilder);
+        $method = $reflection->getMethod('extractOrderItemData');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->rosterBuilder, $order, 4762, $item);
+
+        $this->assertSame(1, $result['girls_only']);
+    }
+
+    public function test_extract_order_item_data_sets_girls_only_from_canonical_meta() {
+        $order = Mockery::mock('WC_Order');
+        $order->shouldReceive('get_id')->andReturn(44);
+        $order->shouldReceive('get_customer_id')->andReturn(9);
+        $order->shouldReceive('get_status')->andReturn('processing');
+
+        $item = Mockery::mock('WC_Order_Item_Product');
+        $item->shouldReceive('get_product')->andReturn(null);
+        $item->shouldReceive('get_variation_id')->andReturn(37640);
+        $item->shouldReceive('get_product_id')->andReturn(37635);
+        $item->shouldReceive('get_meta')->andReturn('');
+        $item->shouldReceive('get_meta_data')->andReturn([
+            $this->createOrderItemMeta('Activity Type', 'Camp'),
+            $this->createOrderItemMeta('_intersoccer_canonical_girls_only', '1'),
+            $this->createOrderItemMeta('pa_program-season', 'summer-camps-2026'),
+            $this->createOrderItemMeta('pa_intersoccer-venues', 'geneva-venue'),
+        ]);
+
+        $reflection = new \ReflectionClass($this->rosterBuilder);
+        $method = $reflection->getMethod('extractOrderItemData');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->rosterBuilder, $order, 4763, $item);
+
+        $this->assertSame(1, $result['girls_only']);
+    }
+
+    public function test_extract_order_item_data_girls_only_no_display_meta_is_zero() {
+        $order = Mockery::mock('WC_Order');
+        $order->shouldReceive('get_id')->andReturn(45);
+        $order->shouldReceive('get_customer_id')->andReturn(10);
+        $order->shouldReceive('get_status')->andReturn('processing');
+
+        $item = Mockery::mock('WC_Order_Item_Product');
+        $item->shouldReceive('get_product')->andReturn(null);
+        $item->shouldReceive('get_variation_id')->andReturn(37641);
+        $item->shouldReceive('get_product_id')->andReturn(37635);
+        $item->shouldReceive('get_meta')->andReturn('');
+        $item->shouldReceive('get_meta_data')->andReturn([
+            $this->createOrderItemMeta('Activity Type', 'Camp'),
+            $this->createOrderItemMeta('Girls Only', 'No'),
+            $this->createOrderItemMeta('pa_program-season', 'summer-camps-2026'),
+            $this->createOrderItemMeta('pa_intersoccer-venues', 'geneva-venue'),
+        ]);
+
+        $reflection = new \ReflectionClass($this->rosterBuilder);
+        $method = $reflection->getMethod('extractOrderItemData');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->rosterBuilder, $order, 4764, $item);
+
+        $this->assertSame(0, $result['girls_only']);
     }
     
     public function test_build_rosters_with_empty_options() {

--- a/tests/Services/RosterListingServiceGirlsOnlyTest.php
+++ b/tests/Services/RosterListingServiceGirlsOnlyTest.php
@@ -30,7 +30,7 @@ class RosterListingServiceGirlsOnlyTest extends TestCase {
         }
     }
 
-    public function test_camp_listings_default_mixed_and_girls_only_page_use_expected_criteria() {
+    public function test_camp_listings_default_all_and_girls_only_page_use_expected_criteria() {
         $captured = [];
         $repository = Mockery::mock(RosterRepository::class);
         $repository->shouldReceive('getListingAggregates')
@@ -44,7 +44,7 @@ class RosterListingServiceGirlsOnlyTest extends TestCase {
         $service->getGirlsOnlyListings([]);
 
         $this->assertCount(2, $captured);
-        // Mixed camps use PHP post-filter so name-based girls-only rows are not lost.
+        // Default All: no girls_only SQL criterion.
         $this->assertArrayNotHasKey('girls_only', $captured[0]);
         $this->assertSame(1, $captured[1]['girls_only']);
     }
@@ -65,7 +65,7 @@ class RosterListingServiceGirlsOnlyTest extends TestCase {
         $this->assertArrayNotHasKey('girls_only', $captured[0]);
     }
 
-    public function test_camp_listings_girls_only_mode_girls_only_omits_sql_flag_for_php_filter() {
+    public function test_camp_listings_girls_only_mode_yes_omits_sql_flag_for_php_filter() {
         $captured = [];
         $repository = Mockery::mock(RosterRepository::class);
         $repository->shouldReceive('getListingAggregates')
@@ -75,13 +75,13 @@ class RosterListingServiceGirlsOnlyTest extends TestCase {
             });
 
         $service = new RosterListingService(null, $repository);
-        $service->getCampListings(['girls_only_mode' => 'girls_only'], [], false);
+        $service->getCampListings(['girls_only_mode' => 'yes'], [], false);
 
         $this->assertCount(1, $captured);
         $this->assertArrayNotHasKey('girls_only', $captured[0]);
     }
 
-    public function test_course_listings_girls_only_mode_girls_only_omits_sql_flag_for_php_filter() {
+    public function test_camp_listings_girls_only_mode_no_omits_sql_flag_for_php_filter() {
         $captured = [];
         $repository = Mockery::mock(RosterRepository::class);
         $repository->shouldReceive('getListingAggregates')
@@ -91,7 +91,23 @@ class RosterListingServiceGirlsOnlyTest extends TestCase {
             });
 
         $service = new RosterListingService(null, $repository);
-        $service->getCourseListings(['girls_only_mode' => 'girls_only'], [], false);
+        $service->getCampListings(['girls_only_mode' => 'no'], [], false);
+
+        $this->assertCount(1, $captured);
+        $this->assertArrayNotHasKey('girls_only', $captured[0]);
+    }
+
+    public function test_course_listings_girls_only_mode_yes_omits_sql_flag_for_php_filter() {
+        $captured = [];
+        $repository = Mockery::mock(RosterRepository::class);
+        $repository->shouldReceive('getListingAggregates')
+            ->andReturnUsing(function ($criteria) use (&$captured) {
+                $captured[] = $criteria;
+                return [];
+            });
+
+        $service = new RosterListingService(null, $repository);
+        $service->getCourseListings(['girls_only_mode' => 'yes'], [], false);
 
         $this->assertGreaterThanOrEqual(1, count($captured));
         foreach ($captured as $criteria) {


### PR DESCRIPTION
Activity Type is Camps/Courses/Tournaments only; Girls Only is an attribute filter with PHP matching so unreconciled Yes-meta rows still list. Resolve honors display/canonical girls-only meta; All Rosters redirects to unified Rosters.