### PR TITLE
Resolve Final Numbers year from program-year and require year on seas…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ WordPress/WooCommerce plugin for event roster management, Final Numbers / Live S
 
 - **Current Version:** 2.7.25
 
-Camp event dates prefer variation `_camp_start_date` / `_camp_end_date` (and order-item stamps) via `intersoccer_reports_resolve_camp_schedule()`. Parsing `camp_terms` strings is a **deprecated transitional fallback** until catalogue migration is complete.
+- Camp event dates prefer variation `_camp_start_date` / `_camp_end_date` (and order-item stamps) via `intersoccer_reports_resolve_camp_schedule()`. Parsing `camp_terms` strings is a **deprecated transitional fallback** until catalogue migration is complete.
+- Final Numbers / Live Snapshot resolve year via `intersoccer_reports_resolve_program_year()`: order-item `Year` / `pa_program-year` → digits in season → event dates. Evergreen seasons (e.g. `Autumn`) no longer require year digits in the season string. Season close requires an explicit year.
 - **Release Date:** July 25, 2026
 
 ## Owns

--- a/classes/Ajax/admin-tools-ajax-handler.php
+++ b/classes/Ajax/admin-tools-ajax-handler.php
@@ -279,10 +279,23 @@ class AdminToolsAjaxHandler {
             wp_send_json_error(['message' => __('Season is required.', 'intersoccer-reports-rosters')]);
         }
 
+        $year = isset($_POST['year']) ? absint($_POST['year']) : 0;
+        if ($year < 2000 && function_exists('intersoccer_extract_year_from_season')) {
+            $extracted = intersoccer_extract_year_from_season($season);
+            if ($extracted !== null) {
+                $year = (int) $extracted;
+            }
+        }
+        if ($year < 2000) {
+            wp_send_json_error([
+                'message' => __('Year is required to close a season. Evergreen seasons (e.g. Autumn) need an explicit year so other years are not closed.', 'intersoccer-reports-rosters'),
+            ]);
+        }
+
         global $wpdb;
         $table = $wpdb->prefix . 'intersoccer_rosters';
 
-        // Match case-insensitively; close ALL rosters in the matching season.
+        // Match case-insensitively; then scope by calendar year (evergreen-safe).
         $season_escaped = $wpdb->esc_like($season);
         $matching_seasons = $wpdb->get_col($wpdb->prepare(
             "SELECT DISTINCT season FROM {$table}
@@ -297,17 +310,53 @@ class AdminToolsAjaxHandler {
         }
 
         $season_placeholders = implode(',', array_fill(0, count($matching_seasons), '%s'));
-        $where_conditions = ["season IN ($season_placeholders)", "(event_completed = 0 OR event_completed IS NULL)"];
+        $candidates = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT id, season, start_date FROM {$table}
+                 WHERE season IN ($season_placeholders)
+                 AND (event_completed = 0 OR event_completed IS NULL)",
+                $matching_seasons
+            ),
+            ARRAY_A
+        );
 
-        $count_query = "SELECT COUNT(DISTINCT event_signature) FROM {$table} WHERE " . implode(' AND ', $where_conditions);
-        $roster_count = (int) $wpdb->get_var($wpdb->prepare($count_query, $matching_seasons));
+        $ids = [];
+        foreach ((array) $candidates as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+            if (function_exists('intersoccer_reports_roster_matches_close_year')
+                ? intersoccer_reports_roster_matches_close_year($row, $year)
+                : false) {
+                $ids[] = (int) $row['id'];
+            }
+        }
+        $ids = array_values(array_filter(array_unique($ids)));
 
-        if ($roster_count <= 0) {
-            wp_send_json_error(['message' => __('No active rosters found for this season.', 'intersoccer-reports-rosters')]);
+        if (empty($ids)) {
+            wp_send_json_error([
+                'message' => sprintf(
+                    __('No active rosters found for season "%1$s" in year %2$d.', 'intersoccer-reports-rosters'),
+                    esc_html($season),
+                    $year
+                ),
+            ]);
         }
 
-        $update_query = "UPDATE {$table} SET event_completed = 1 WHERE " . implode(' AND ', $where_conditions);
-        $updated = $wpdb->query($wpdb->prepare($update_query, $matching_seasons));
+        $id_placeholders = implode(',', array_fill(0, count($ids), '%d'));
+        $roster_count = (int) $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT COUNT(DISTINCT event_signature) FROM {$table} WHERE id IN ($id_placeholders)",
+                $ids
+            )
+        );
+
+        $updated = $wpdb->query(
+            $wpdb->prepare(
+                "UPDATE {$table} SET event_completed = 1 WHERE id IN ($id_placeholders)",
+                $ids
+            )
+        );
 
         if ($updated === false) {
             wp_send_json_error(['message' => __('Failed to close rosters in season.', 'intersoccer-reports-rosters')]);
@@ -315,7 +364,13 @@ class AdminToolsAjaxHandler {
 
         delete_transient('intersoccer_rosters_cache');
 
-        $season_msg = sprintf(__('Successfully closed %d roster(s) in season "%s". %d entries updated.', 'intersoccer-reports-rosters'), $roster_count, esc_html($season), $updated);
+        $season_msg = sprintf(
+            __('Successfully closed %1$d roster(s) in season "%2$s" (%3$d). %4$d entries updated.', 'intersoccer-reports-rosters'),
+            $roster_count,
+            esc_html($season),
+            $year,
+            $updated
+        );
         if (function_exists('intersoccer_rosters_flash_admin_notice')) {
             intersoccer_rosters_flash_admin_notice($season_msg);
         }
@@ -325,6 +380,7 @@ class AdminToolsAjaxHandler {
             'updated' => $updated,
             'roster_count' => $roster_count,
             'season' => $season,
+            'year' => $year,
         ]);
     }
 

--- a/includes/advanced.php
+++ b/includes/advanced.php
@@ -2686,23 +2686,29 @@ function intersoccer_close_season_rosters_ajax() {
     if (empty($season)) {
         wp_send_json_error(['message' => __('Season is required.', 'intersoccer-reports-rosters')]);
     }
+
+    $year = isset($_POST['year']) ? absint($_POST['year']) : 0;
+    if ($year < 2000 && function_exists('intersoccer_extract_year_from_season')) {
+        $extracted = intersoccer_extract_year_from_season($season);
+        if ($extracted !== null) {
+            $year = (int) $extracted;
+        }
+    }
+    if ($year < 2000) {
+        wp_send_json_error([
+            'message' => __('Year is required to close a season. Evergreen seasons (e.g. Autumn) need an explicit year so other years are not closed.', 'intersoccer-reports-rosters'),
+        ]);
+    }
     
     // Normalize the season for matching (handle display format vs database format)
-    // The season might be in display format (e.g., "Winter 2025") but stored differently in DB
-    // Use case-insensitive matching to find all matching season values
     if (!function_exists('intersoccer_normalize_season_for_display')) {
-        // Fallback if function doesn't exist
         $normalized_season = $season;
     } else {
         $normalized_season = intersoccer_normalize_season_for_display($season);
     }
     
-    // Use a simpler, more efficient query to find matching seasons
-    // Match case-insensitively and handle variations
     $season_escaped = $wpdb->esc_like($season);
-    $normalized_escaped = $wpdb->esc_like($normalized_season);
     
-    // Get all distinct season values that match (case-insensitive)
     $matching_seasons = $wpdb->get_col($wpdb->prepare(
         "SELECT DISTINCT season FROM {$rosters_table} 
          WHERE (event_completed = 0 OR event_completed IS NULL) 
@@ -2717,27 +2723,57 @@ function intersoccer_close_season_rosters_ajax() {
     if (empty($matching_seasons)) {
         wp_send_json_error(['message' => sprintf(__('No active rosters found for season "%s".', 'intersoccer-reports-rosters'), esc_html($season))]);
     }
-    
-    // Build WHERE clause - match any of the found season values
-    // Close ALL rosters in the season regardless of page type
+
     $season_placeholders = implode(',', array_fill(0, count($matching_seasons), '%s'));
-    $where_conditions = ["season IN ($season_placeholders)", "(event_completed = 0 OR event_completed IS NULL)"];
-    $where_params = $matching_seasons;
-    
-    // Log what we're about to do
-    error_log('InterSoccer: Closing season rosters - Season: ' . $season . ', Matching seasons: ' . implode(', ', $matching_seasons) . ', Page: ' . $page);
-    
-    // Count how many will be affected
-    $count_query = "SELECT COUNT(DISTINCT event_signature) FROM {$rosters_table} WHERE " . implode(' AND ', $where_conditions);
-    $roster_count = $wpdb->get_var($wpdb->prepare($count_query, $where_params));
-    
-    if ($roster_count == 0) {
-        wp_send_json_error(['message' => __('No active rosters found for this season.', 'intersoccer-reports-rosters')]);
+    $candidates = $wpdb->get_results(
+        $wpdb->prepare(
+            "SELECT id, season, start_date FROM {$rosters_table}
+             WHERE season IN ($season_placeholders)
+             AND (event_completed = 0 OR event_completed IS NULL)",
+            $matching_seasons
+        ),
+        ARRAY_A
+    );
+
+    $ids = [];
+    foreach ((array) $candidates as $row) {
+        if (!is_array($row)) {
+            continue;
+        }
+        if (function_exists('intersoccer_reports_roster_matches_close_year')
+            ? intersoccer_reports_roster_matches_close_year($row, $year)
+            : false) {
+            $ids[] = (int) $row['id'];
+        }
     }
-    
-    // Update all roster entries for this season (all types)
-    $update_query = "UPDATE {$rosters_table} SET event_completed = 1 WHERE " . implode(' AND ', $where_conditions);
-    $updated = $wpdb->query($wpdb->prepare($update_query, $where_params));
+    $ids = array_values(array_filter(array_unique($ids)));
+
+    if (empty($ids)) {
+        wp_send_json_error([
+            'message' => sprintf(
+                __('No active rosters found for season "%1$s" in year %2$d.', 'intersoccer-reports-rosters'),
+                esc_html($season),
+                $year
+            ),
+        ]);
+    }
+
+    $id_placeholders = implode(',', array_fill(0, count($ids), '%d'));
+    $roster_count = (int) $wpdb->get_var(
+        $wpdb->prepare(
+            "SELECT COUNT(DISTINCT event_signature) FROM {$rosters_table} WHERE id IN ($id_placeholders)",
+            $ids
+        )
+    );
+
+    error_log('InterSoccer: Closing season rosters - Season: ' . $season . ', Year: ' . $year . ', Page: ' . $page . ', IDs: ' . count($ids));
+
+    $updated = $wpdb->query(
+        $wpdb->prepare(
+            "UPDATE {$rosters_table} SET event_completed = 1 WHERE id IN ($id_placeholders)",
+            $ids
+        )
+    );
     
     error_log('InterSoccer: Closed season rosters - Updated: ' . $updated . ' entries, Rosters: ' . $roster_count);
     
@@ -2745,16 +2781,22 @@ function intersoccer_close_season_rosters_ajax() {
         wp_send_json_error(['message' => __('Failed to close rosters in season.', 'intersoccer-reports-rosters')]);
     }
     
-    // Log audit trail
-    intersoccer_log_audit('Season Rosters Closed', "Season: $season, Page: $page, Rosters: $roster_count, Entries: $updated");
+    intersoccer_log_audit('Season Rosters Closed', "Season: $season, Year: $year, Page: $page, Rosters: $roster_count, Entries: $updated");
     
     delete_transient('intersoccer_rosters_cache');
     
     wp_send_json_success([
-        'message' => sprintf(__('Successfully closed %d roster(s) in season "%s". %d entries updated.', 'intersoccer-reports-rosters'), $roster_count, esc_html($season), $updated),
+        'message' => sprintf(
+            __('Successfully closed %1$d roster(s) in season "%2$s" (%3$d). %4$d entries updated.', 'intersoccer-reports-rosters'),
+            $roster_count,
+            esc_html($season),
+            $year,
+            $updated
+        ),
         'updated' => $updated,
         'roster_count' => $roster_count,
-        'season' => $season
+        'season' => $season,
+        'year' => $year,
     ]);
 }
 

--- a/includes/final-reports-aggregation.php
+++ b/includes/final-reports-aggregation.php
@@ -9,6 +9,83 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+if (!function_exists('intersoccer_reports_resolve_program_year')) {
+    /**
+     * Resolve program year for a Final Numbers / report entry.
+     *
+     * Priority: explicit program_year / Year meta → digits in season → event/start date year.
+     *
+     * @param array<string,mixed> $entry Roster or report row.
+     * @return int|null
+     */
+    function intersoccer_reports_resolve_program_year(array $entry) {
+        foreach (['program_year', 'Year', 'pa_program-year'] as $key) {
+            if (!isset($entry[$key]) || $entry[$key] === '' || $entry[$key] === null) {
+                continue;
+            }
+            $raw = trim((string) $entry[$key]);
+            if ($raw === '') {
+                continue;
+            }
+            if (preg_match('/\b(20\d{2})\b/', $raw, $m)) {
+                return (int) $m[1];
+            }
+            if (preg_match('/^(19|20)\d{2}$/', $raw)) {
+                return (int) $raw;
+            }
+        }
+
+        $season = '';
+        if (!empty($entry['season'])) {
+            $season = (string) $entry['season'];
+        } elseif (!empty($entry['roster_season'])) {
+            $season = (string) $entry['roster_season'];
+        }
+        if ($season !== '' && function_exists('intersoccer_extract_year_from_season')) {
+            $from_season = intersoccer_extract_year_from_season($season);
+            if ($from_season !== null) {
+                return (int) $from_season;
+            }
+        }
+
+        foreach (['event_start_date', 'start_date'] as $date_key) {
+            if (empty($entry[$date_key])) {
+                continue;
+            }
+            $date = trim((string) $entry[$date_key]);
+            if ($date === '' || $date === '1970-01-01' || $date === '0000-00-00' || $date === 'N/A') {
+                continue;
+            }
+            $ts = strtotime($date);
+            if ($ts !== false) {
+                return (int) date('Y', $ts);
+            }
+        }
+
+        return null;
+    }
+}
+
+if (!function_exists('intersoccer_reports_roster_matches_close_year')) {
+    /**
+     * Whether a roster row should be closed for the requested calendar year.
+     *
+     * @param array<string,mixed> $row
+     * @param int                 $year Required year (must be >= 2000).
+     * @return bool
+     */
+    function intersoccer_reports_roster_matches_close_year(array $row, $year) {
+        $year = (int) $year;
+        if ($year < 2000) {
+            return false;
+        }
+        $resolved = function_exists('intersoccer_reports_resolve_program_year')
+            ? intersoccer_reports_resolve_program_year($row)
+            : null;
+        return $resolved !== null && (int) $resolved === $year;
+    }
+}
+
 if (!function_exists('intersoccer_reports_order_status_allowed_for_mode')) {
     /**
      * Whether a WooCommerce order status is counted for Final Numbers mode.
@@ -60,17 +137,22 @@ if (!function_exists('intersoccer_reports_filter_entries_by_season_year')) {
                 }
             }
 
-            $season_year = ($season !== '' && function_exists('intersoccer_extract_year_from_season'))
-                ? intersoccer_extract_year_from_season($season)
+            $resolved_year = function_exists('intersoccer_reports_resolve_program_year')
+                ? intersoccer_reports_resolve_program_year($entry)
                 : null;
 
-            if ($season_year !== null) {
-                if ((int) $season_year === $requested_year) {
+            if ($resolved_year === null && $season !== '' && function_exists('intersoccer_extract_year_from_season')) {
+                $resolved_year = intersoccer_extract_year_from_season($season);
+            }
+
+            if ($resolved_year !== null) {
+                if ((int) $resolved_year === $requested_year) {
                     $out[] = $entry;
                 }
                 continue;
             }
 
+            // Last resort: event/start date when resolver unavailable or empty entry.
             $esd = isset($entry['event_start_date']) ? trim((string) $entry['event_start_date']) : '';
             if ($esd === '' || $esd === '1970-01-01' || $esd === '0000-00-00') {
                 $esd = isset($entry['start_date']) ? trim((string) $entry['start_date']) : '';

--- a/includes/order-meta-keys.php
+++ b/includes/order-meta-keys.php
@@ -34,6 +34,8 @@ function intersoccer_get_order_meta_field_map() {
         'Player Index' => 'player_index',
         'Days Selected' => 'selected_days',
         'Season' => 'season',
+        'Year' => 'program_year',
+        'pa_program-year' => 'program_year',
         'Canton / Region' => 'region',
         'City' => 'city',
         'Activity Type' => 'activity_type',
@@ -784,6 +786,8 @@ function intersoccer_get_order_meta_canonical_to_final_report_row_keys() {
         'Days Selected' => 'selected_days',
         'Camp Terms' => 'camp_terms',
         'Season' => 'season',
+        'Year' => 'program_year',
+        'pa_program-year' => 'program_year',
     ];
 }
 

--- a/includes/reports-data.php
+++ b/includes/reports-data.php
@@ -201,22 +201,21 @@ function intersoccer_get_final_reports_data($year, $activity_type, $season_type 
             : '%s';
         
         // Build WHERE conditions dynamically based on filters
-        // Exclude placeholder records (order_item_id = 0)
+        // Exclude placeholder records (order_item_id = 0).
+        // Do NOT require year digits in r.season (evergreen seasons like "Autumn").
+        // Year is resolved in PHP via program_year / season digits / event dates.
         $where_conditions = [
             "r.activity_type = %s",
-            "r.season LIKE %s",
             "r.order_item_id > 0",
             "p.post_type = 'shop_order'",
             "p.post_status IN ({$camp_status_sql})"
         ];
         $prepare_values = [
             $activity_type,
-            '%' . $year_int . '%'
         ];
         $prepare_values = array_merge($prepare_values, $camp_statuses);
         
-        // Add season type filter if provided (AFTER camp_statuses so binding
-        // order matches: activity_type, season LIKE, post_status IN, season_type LIKE).
+        // Add season type filter if provided (type only — e.g. Autumn%, not year digits).
         if (!empty($season_type)) {
             $where_conditions[] = "r.season LIKE %s";
             $prepare_values[] = $season_type . '%';
@@ -246,12 +245,15 @@ function intersoccer_get_final_reports_data($year, $activity_type, $season_type 
                 oi.order_id,
                 om_line_subtotal.meta_value AS line_subtotal,
                 om_line_total.meta_value AS line_total,
+                COALESCE(om_year.meta_value, om_year_alt.meta_value) AS program_year,
                 p.post_date
              FROM $rosters_table r
              JOIN $order_items_table oi ON r.order_item_id = oi.order_item_id
              JOIN $posts_table p ON oi.order_id = p.ID
              LEFT JOIN $order_itemmeta_table om_line_subtotal ON oi.order_item_id = om_line_subtotal.order_item_id AND om_line_subtotal.meta_key = '_line_subtotal'
              LEFT JOIN $order_itemmeta_table om_line_total ON oi.order_item_id = om_line_total.order_item_id AND om_line_total.meta_key = '_line_total'
+             LEFT JOIN $order_itemmeta_table om_year ON oi.order_item_id = om_year.order_item_id AND om_year.meta_key = 'Year'
+             LEFT JOIN $order_itemmeta_table om_year_alt ON oi.order_item_id = om_year_alt.order_item_id AND om_year_alt.meta_key = 'pa_program-year'
              WHERE $where_clause",
             ...$prepare_values
         );
@@ -468,8 +470,10 @@ function intersoccer_get_final_reports_data($year, $activity_type, $season_type 
                         $roster['event_start_date'] = $event_start_date;
                         $roster['event_end_date'] = $event_end_date ?: $event_start_date;
                     } else {
-                        // Keep undated rows if season still matches requested year so table and totals stay aligned.
-                        $season_year_undated = !empty($roster['season']) ? intersoccer_extract_year_from_season($roster['season']) : null;
+                        // Keep undated rows if program year still matches requested year.
+                        $season_year_undated = function_exists('intersoccer_reports_resolve_program_year')
+                            ? intersoccer_reports_resolve_program_year($roster)
+                            : (!empty($roster['season']) ? intersoccer_extract_year_from_season($roster['season']) : null);
                         $requested_year_int = intval($year);
                         if ($season_year_undated !== null && $season_year_undated == $requested_year_int) {
                             $roster['event_start_date'] = '';
@@ -489,8 +493,10 @@ function intersoccer_get_final_reports_data($year, $activity_type, $season_type 
                     }
                 }
                 
-                // For camps, season is authoritative - match the user's query behavior (season LIKE '%year')
-                $season_year = !empty($roster['season']) ? intersoccer_extract_year_from_season($roster['season']) : null;
+                // Prefer program_year / season digits / event dates (evergreen-safe).
+                $season_year = function_exists('intersoccer_reports_resolve_program_year')
+                    ? intersoccer_reports_resolve_program_year($roster)
+                    : (!empty($roster['season']) ? intersoccer_extract_year_from_season($roster['season']) : null);
                 $requested_year_int = intval($year);
                 
                 // Apply season type filter if provided
@@ -512,7 +518,7 @@ function intersoccer_get_final_reports_data($year, $activity_type, $season_type 
                     }
                 }
                 
-                // Primary filter: season year must match (like user's query: season LIKE '%year')
+                // Primary filter: resolved program year must match
                 if ($season_year !== null) {
                     if ($season_year == $requested_year_int) {
                         // Season matches - include this record
@@ -526,7 +532,7 @@ function intersoccer_get_final_reports_data($year, $activity_type, $season_type 
                         continue;
                     }
                 } else {
-                    // No season - fall back to date-based filtering
+                    // No resolvable year - fall back to date-based filtering
                     $event_year = !empty($roster['event_start_date']) ? intval(date('Y', strtotime($roster['event_start_date']))) : null;
                     if ($event_year !== null && $event_year == $requested_year_int) {
                         $after_season_filter++;
@@ -576,7 +582,9 @@ function intersoccer_get_final_reports_data($year, $activity_type, $season_type 
             
             // Parse event dates from camp_terms
             if (empty($camp_terms) || $camp_terms === 'N/A') {
-                $season_year_undated = !empty($season) ? intersoccer_extract_year_from_season($season) : null;
+                $season_year_undated = function_exists('intersoccer_reports_resolve_program_year')
+                    ? intersoccer_reports_resolve_program_year(array_merge($roster, ['season' => $season]))
+                    : (!empty($season) ? intersoccer_extract_year_from_season($season) : null);
                 if ($season_year_undated !== null && $season_year_undated == intval($year)) {
                     $roster['event_start_date'] = '';
                     $roster['event_end_date'] = '';
@@ -898,7 +906,10 @@ function intersoccer_get_final_reports_data($year, $activity_type, $season_type 
 
             if (empty($parsed_start_date) || $parsed_start_date === '1970-01-01') {
                 $season_for_year = $roster['roster_season'] ?? '';
-                $season_year = !empty($season_for_year) ? intersoccer_extract_year_from_season($season_for_year) : null;
+                $resolve_entry = array_merge($roster, ['season' => $season_for_year]);
+                $season_year = function_exists('intersoccer_reports_resolve_program_year')
+                    ? intersoccer_reports_resolve_program_year($resolve_entry)
+                    : (!empty($season_for_year) ? intersoccer_extract_year_from_season($season_for_year) : null);
                 $requested_year_int = intval($year);
                 if ($season_year !== null && $season_year == $requested_year_int) {
                     $post_date = isset($roster['post_date']) ? trim((string) $roster['post_date']) : '';
@@ -916,7 +927,10 @@ function intersoccer_get_final_reports_data($year, $activity_type, $season_type 
 
             if ($start_year != $year && $end_year != $year) {
                 $season_for_year = $roster['roster_season'] ?? '';
-                $season_year = !empty($season_for_year) ? intersoccer_extract_year_from_season($season_for_year) : null;
+                $resolve_entry = array_merge($roster, ['season' => $season_for_year]);
+                $season_year = function_exists('intersoccer_reports_resolve_program_year')
+                    ? intersoccer_reports_resolve_program_year($resolve_entry)
+                    : (!empty($season_for_year) ? intersoccer_extract_year_from_season($season_for_year) : null);
                 if ($season_year === null || $season_year != intval($year)) {
                     continue;
                 }

--- a/includes/rosters.php
+++ b/includes/rosters.php
@@ -1001,7 +1001,18 @@ function intersoccer_roster_listing_page_scripts() {
             var $btn = $(this);
             var season = $btn.data('season');
             var page = $btn.data('page') || 'camps';
-            if (!confirm('<?php echo esc_js(__('Are you sure you want to close ALL active rosters in this season? This action cannot be undone.', 'intersoccer-reports-rosters')); ?>')) {
+            var year = parseInt($btn.data('year'), 10) || 0;
+            if (!year && season) {
+                var yearMatch = String(season).match(/\b(20\d{2})\b/);
+                if (yearMatch) {
+                    year = parseInt(yearMatch[1], 10);
+                }
+            }
+            if (!year) {
+                alert('<?php echo esc_js(__('Year is required to close a season. Filter or label the season with a year (e.g. Autumn 2026) before closing.', 'intersoccer-reports-rosters')); ?>');
+                return;
+            }
+            if (!confirm('<?php echo esc_js(__('Are you sure you want to close ALL active rosters in this season for the selected year? This action cannot be undone.', 'intersoccer-reports-rosters')); ?>')) {
                 return;
             }
             $btn.prop('disabled', true).text('<?php echo esc_js(__('Closing...', 'intersoccer-reports-rosters')); ?>');
@@ -1012,6 +1023,7 @@ function intersoccer_roster_listing_page_scripts() {
                     action: 'intersoccer_close_season_rosters',
                     nonce: '<?php echo wp_create_nonce('intersoccer_reports_rosters_nonce'); ?>',
                     season: season,
+                    year: year,
                     page: page
                 },
                 success: function(response) {
@@ -1700,8 +1712,26 @@ function intersoccer_render_camps_page() {
                             </div>
                             <div class="season-actions">
                                 <?php if ($active_count > 0): ?>
+                                    <?php
+                                    $close_year = function_exists('intersoccer_extract_year_from_season')
+                                        ? intersoccer_extract_year_from_season($season)
+                                        : null;
+                                    if ($close_year === null && !empty($camps) && function_exists('intersoccer_reports_resolve_program_year')) {
+                                        $years = [];
+                                        foreach ($camps as $camp_row) {
+                                            $y = intersoccer_reports_resolve_program_year(is_array($camp_row) ? $camp_row : (array) $camp_row);
+                                            if ($y !== null) {
+                                                $years[$y] = true;
+                                            }
+                                        }
+                                        if (count($years) === 1) {
+                                            $close_year = (int) array_key_first($years);
+                                        }
+                                    }
+                                    ?>
                                     <button type="button" class="close-season-btn" 
                                             data-season="<?php echo esc_attr($season); ?>"
+                                            data-year="<?php echo esc_attr($close_year !== null ? (string) (int) $close_year : ''); ?>"
                                             data-page="camps"
                                             title="<?php esc_attr_e('Close all active rosters in this season', 'intersoccer-reports-rosters'); ?>">
                                         <?php _e('Close All in Season', 'intersoccer-reports-rosters'); ?>
@@ -2139,8 +2169,28 @@ function intersoccer_render_courses_page() {
                             </div>
                             <div class="season-actions">
                                 <?php if ($active_count > 0): ?>
+                                    <?php
+                                    $close_year = function_exists('intersoccer_extract_year_from_season')
+                                        ? intersoccer_extract_year_from_season($season)
+                                        : null;
+                                    if ($close_year === null && !empty($day_groups) && function_exists('intersoccer_reports_resolve_program_year')) {
+                                        $years = [];
+                                        foreach ($day_groups as $courses) {
+                                            foreach ((array) $courses as $course_row) {
+                                                $y = intersoccer_reports_resolve_program_year(is_array($course_row) ? $course_row : (array) $course_row);
+                                                if ($y !== null) {
+                                                    $years[$y] = true;
+                                                }
+                                            }
+                                        }
+                                        if (count($years) === 1) {
+                                            $close_year = (int) array_key_first($years);
+                                        }
+                                    }
+                                    ?>
                                     <button type="button" class="close-season-btn" 
                                             data-season="<?php echo esc_attr($season); ?>"
+                                            data-year="<?php echo esc_attr($close_year !== null ? (string) (int) $close_year : ''); ?>"
                                             data-page="courses"
                                             title="<?php esc_attr_e('Close all active rosters in this season', 'intersoccer-reports-rosters'); ?>">
                                         <?php _e('Close All in Season', 'intersoccer-reports-rosters'); ?>

--- a/tests/Reports/EvergreenYearIsolationTest.php
+++ b/tests/Reports/EvergreenYearIsolationTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Evergreen season year isolation helpers (no full RR TestCase / vendor required).
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class EvergreenYearIsolationTest extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+		if (!defined('ABSPATH')) {
+			define('ABSPATH', dirname(__DIR__, 2) . '/');
+		}
+		$includes = dirname(__DIR__, 2) . '/includes';
+		require_once $includes . '/final-reports-aggregation.php';
+		if (!function_exists('intersoccer_extract_year_from_season')) {
+			// Prefer reports-data extractors when available; otherwise local stubs below.
+			$reports_data = $includes . '/reports-data.php';
+			if (file_exists($reports_data)) {
+				// Avoid loading full reports-data (heavy requires) — stubs are enough for this suite.
+			}
+		}
+		if (!function_exists('intersoccer_extract_year_from_season')) {
+			function intersoccer_extract_year_from_season($season) {
+				if (empty($season)) {
+					return null;
+				}
+				if (preg_match('/(\d{4})/', $season, $matches)) {
+					return intval($matches[1]);
+				}
+				return null;
+			}
+		}
+		if (!function_exists('intersoccer_extract_season_type')) {
+			function intersoccer_extract_season_type($season) {
+				foreach (['Summer', 'Winter', 'Autumn', 'Spring', 'Easter', 'Halloween'] as $type) {
+					if (stripos((string) $season, $type) !== false) {
+						return $type;
+					}
+				}
+				return null;
+			}
+		}
+	}
+
+	public function test_evergreen_program_year_isolation() {
+		$entries = [
+			['order_item_id' => 1, 'season' => 'Autumn', 'program_year' => '2026', 'event_start_date' => '2026-10-05'],
+			['order_item_id' => 2, 'season' => 'Autumn', 'program_year' => '2027', 'event_start_date' => '2027-10-04'],
+			['order_item_id' => 3, 'season' => 'Autumn 2026', 'event_start_date' => '2026-10-12'],
+			['order_item_id' => 4, 'season' => 'Autumn', 'program_year' => '2026'],
+		];
+		$filtered = intersoccer_reports_filter_entries_by_season_year($entries, 2026, 'Autumn');
+		$this->assertCount(3, $filtered);
+		$ids = array_column($filtered, 'order_item_id');
+		$this->assertContains(1, $ids);
+		$this->assertContains(3, $ids);
+		$this->assertContains(4, $ids);
+		$this->assertNotContains(2, $ids);
+	}
+
+	public function test_close_year_helper() {
+		$row = ['season' => 'Autumn', 'program_year' => '2026', 'start_date' => '2026-10-05'];
+		$this->assertTrue(intersoccer_reports_roster_matches_close_year($row, 2026));
+		$this->assertFalse(intersoccer_reports_roster_matches_close_year($row, 2027));
+		$this->assertFalse(intersoccer_reports_roster_matches_close_year($row, 0));
+	}
+}

--- a/tests/Reports/FinalReportsAggregationAccuracyTest.php
+++ b/tests/Reports/FinalReportsAggregationAccuracyTest.php
@@ -33,7 +33,9 @@ class FinalReportsAggregationAccuracyTest extends TestCase {
             || !function_exists('intersoccer_reports_filter_entries_by_season_year')
             || !function_exists('intersoccer_reports_build_course_report_from_entries')
             || !function_exists('intersoccer_reports_camp_excel_data_rows')
-            || !function_exists('intersoccer_reports_order_status_allowed_for_mode')) {
+            || !function_exists('intersoccer_reports_order_status_allowed_for_mode')
+            || !function_exists('intersoccer_reports_resolve_program_year')
+            || !function_exists('intersoccer_reports_roster_matches_close_year')) {
             $this->markTestSkipped('Final reports aggregation helpers not loaded');
         }
     }
@@ -292,6 +294,62 @@ class FinalReportsAggregationAccuracyTest extends TestCase {
         $filtered = intersoccer_reports_filter_entries_by_season_year($entries, 2026, 'Summer');
         $this->assertCount(1, $filtered);
         $this->assertSame('Summer 2026', $filtered[0]['season']);
+    }
+
+    public function test_evergreen_season_uses_program_year() {
+        $this->skipIfMissingHelpers();
+
+        $entries = [
+            [
+                'order_item_id' => 1,
+                'season' => 'Autumn',
+                'program_year' => '2026',
+                'booking_type' => 'Full Week',
+                'event_start_date' => '2026-10-05',
+            ],
+            [
+                'order_item_id' => 2,
+                'season' => 'Autumn',
+                'program_year' => '2027',
+                'booking_type' => 'Full Week',
+                'event_start_date' => '2027-10-04',
+            ],
+            [
+                'order_item_id' => 3,
+                'season' => 'Autumn 2026',
+                'booking_type' => 'Full Week',
+                'event_start_date' => '2026-10-12',
+            ],
+            [
+                'order_item_id' => 4,
+                'season' => 'Autumn',
+                'program_year' => '2026',
+                'booking_type' => 'Full Week',
+                // Undated — kept via program_year
+            ],
+        ];
+
+        $filtered = intersoccer_reports_filter_entries_by_season_year($entries, 2026, 'Autumn');
+        $this->assertCount(3, $filtered);
+        $ids = array_column($filtered, 'order_item_id');
+        $this->assertContains(1, $ids);
+        $this->assertContains(3, $ids);
+        $this->assertContains(4, $ids);
+        $this->assertNotContains(2, $ids);
+
+        $this->assertSame(2026, intersoccer_reports_resolve_program_year($entries[0]));
+        $this->assertSame(2027, intersoccer_reports_resolve_program_year($entries[1]));
+        $this->assertSame(2026, intersoccer_reports_resolve_program_year($entries[2]));
+    }
+
+    public function test_close_season_requires_year_helper() {
+        $this->skipIfMissingHelpers();
+
+        $row_2026 = ['season' => 'Autumn', 'program_year' => '2026', 'start_date' => '2026-10-05'];
+        $row_2027 = ['season' => 'Autumn', 'program_year' => '2027', 'start_date' => '2027-10-04'];
+        $this->assertTrue(intersoccer_reports_roster_matches_close_year($row_2026, 2026));
+        $this->assertFalse(intersoccer_reports_roster_matches_close_year($row_2027, 2026));
+        $this->assertFalse(intersoccer_reports_roster_matches_close_year($row_2026, 0));
     }
 
     public function test_live_vs_final_order_status_mode() {


### PR DESCRIPTION
…on close.

Prefer Year meta and event dates over season digits so evergreen Autumn rows stay year-scoped.