### PR TITLE
Prefer human camp schedule labels when reading order item meta.

### DIFF
--- a/classes/Campaign/FacetNormalizer.php
+++ b/classes/Campaign/FacetNormalizer.php
@@ -114,7 +114,13 @@ class FacetNormalizer {
 			$out['age_group'] = $this->normalize_age_group($age);
 		}
 
-		$week_index = $this->first_meta($raw, ['_camp_week_index', 'Camp Week Index']);
+		// Prefer human week labels (EN/FR/DE); `_camp_week_index` is legacy order-item fallback.
+		$week_index = $this->first_meta($raw, [
+			'Camp Week Index',
+			'Index de semaine du camp',
+			'Camp-Wochenindex',
+			'_camp_week_index',
+		]);
 		if ($week_index !== '' && is_numeric($week_index)) {
 			$out['camp_week_index'] = (int) $week_index;
 		}

--- a/includes/order-meta-keys.php
+++ b/includes/order-meta-keys.php
@@ -42,6 +42,9 @@ function intersoccer_get_order_meta_field_map() {
         'Girls Only' => 'girls_only',
         'Start Date' => 'start_date',
         'End Date' => 'end_date',
+        'Camp Start Date' => 'camp_start_date',
+        'Camp End Date' => 'camp_end_date',
+        'Camp Week Index' => 'camp_week_index',
         'Holidays' => 'holidays',
         'Discount' => 'discount_applied',
         'Discount Amount' => 'discount_amount',
@@ -172,6 +175,21 @@ function intersoccer_get_order_meta_manual_aliases() {
         'End Date' => [
             'date de fin',
             'enddatum',
+        ],
+        'Camp Start Date' => [
+            'date de début du camp',
+            'camp-startdatum',
+            'camp start date',
+        ],
+        'Camp End Date' => [
+            'date de fin du camp',
+            'camp-enddatum',
+            'camp end date',
+        ],
+        'Camp Week Index' => [
+            'index de semaine du camp',
+            'camp-wochenindex',
+            'camp week index',
         ],
         'Holidays' => [
             'vacances',

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -6135,7 +6135,13 @@ function intersoccer_reports_resolve_camp_schedule($variation_id, $order_item_id
     }
 
     if (empty($start) && $order_item_id && function_exists('wc_get_order_item_meta')) {
-        foreach (['_camp_start_date', 'Camp Start Date'] as $key) {
+        // Prefer human labels (EN/FR/DE); `_camp_*` is legacy order-item dual-write fallback.
+        foreach ([
+            'Camp Start Date',
+            'Date de début du camp',
+            'Camp-Startdatum',
+            '_camp_start_date',
+        ] as $key) {
             $raw = wc_get_order_item_meta($order_item_id, $key, true);
             if (is_string($raw) && preg_match('/^\d{4}-\d{2}-\d{2}$/', trim($raw))) {
                 $start = trim($raw);
@@ -6143,7 +6149,12 @@ function intersoccer_reports_resolve_camp_schedule($variation_id, $order_item_id
                 break;
             }
         }
-        foreach (['_camp_end_date', 'Camp End Date'] as $key) {
+        foreach ([
+            'Camp End Date',
+            'Date de fin du camp',
+            'Camp-Enddatum',
+            '_camp_end_date',
+        ] as $key) {
             $raw = wc_get_order_item_meta($order_item_id, $key, true);
             if (is_string($raw) && preg_match('/^\d{4}-\d{2}-\d{2}$/', trim($raw))) {
                 $end = trim($raw);


### PR DESCRIPTION
Resolve start/end/week from localized labels first with FR/DE aliases, keeping _camp_* as a legacy fallback for unrepaired lines.